### PR TITLE
Support container scan

### DIFF
--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -51,19 +51,14 @@ describe('Docker#scan()', () => {
     'imagename/app'
   )
 
-  test('build', async () => {
+  beforeAll(async () => {
     jest.spyOn(dockerUtil, 'noBuiltImage').mockResolvedValue(true)
     jest.spyOn(dockerUtil, 'latestBuiltImage').mockResolvedValueOnce({
       imageID: '1234567890',
       imageName: 'build-image/debug',
       tags: ['latest']
     })
-    const result = await docker.build('build')
-    expect(result).toEqual({
-      imageID: '1234567890',
-      imageName: 'build-image/debug',
-      tags: ['latest']
-    })
+    await docker.build('build')
   })
 
   test('scan passed', async () => {

--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -1,5 +1,6 @@
 import Docker from '../src/docker'
 import * as dockerUtil from '../src/docker-util'
+import * as exec from '@actions/exec'
 
 describe('constructor', () => {
   test('registry and imageName is given', async () => {
@@ -41,5 +42,39 @@ describe('Docker#build()', () => {
   test('throw error when built image exists on the machine', async () => {
     jest.spyOn(dockerUtil, 'noBuiltImage').mockResolvedValue(false)
     await expect(docker.build('build')).rejects.toThrowError()
+  })
+})
+
+describe('Docker#scan()', () => {
+  const docker = new Docker(
+    '1234567890.dkr.ecr.ap-northeast-1.amazonaws.com/',
+    'imagename/app'
+  )
+
+  test('build', async () => {
+    jest.spyOn(dockerUtil, 'noBuiltImage').mockResolvedValue(true)
+    jest.spyOn(dockerUtil, 'latestBuiltImage').mockResolvedValueOnce({
+      imageID: '1234567890',
+      imageName: 'build-image/debug',
+      tags: ['latest']
+    })
+    const result = await docker.build('build')
+    expect(result).toEqual({
+      imageID: '1234567890',
+      imageName: 'build-image/debug',
+      tags: ['latest']
+    })
+  })
+
+  test('scan passed', async () => {
+    jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
+    const result = await docker.scan()
+    expect(result).toEqual(0)
+  })
+
+  test('scan failed', async () => {
+    jest.spyOn(exec, 'exec').mockResolvedValueOnce(1)
+    const result = await docker.scan()
+    expect(result).toEqual(1)
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -991,6 +991,7 @@ function run() {
             const docker = new docker_1.default(registry, imageName);
             core.debug(`docker: ${docker.toString()}`);
             yield docker.build(target);
+            yield docker.scan();
             yield docker.push();
         }
         catch (error) {
@@ -1057,6 +1058,24 @@ class Docker {
             }
             catch (e) {
                 core.debug('build() error');
+                throw e;
+            }
+        });
+    }
+    scan() {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                if (!this.builtImage) {
+                    throw new Error('No built image to scan');
+                }
+                const result = exec.exec('trivy', [
+                    '--no-progress',
+                    `${this.builtImage.imageName}:${this.builtImage.tags[0]}`
+                ]);
+                return result;
+            }
+            catch (e) {
+                core.error('scan() error');
                 throw e;
             }
         });

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -41,6 +41,23 @@ export default class Docker {
     }
   }
 
+  async scan(): Promise<number> {
+    try {
+      if (!this.builtImage) {
+        throw new Error('No built image to scan')
+      }
+
+      const result = exec.exec('trivy', [
+        '--no-progress',
+        `${this.builtImage.imageName}:${this.builtImage.tags[0]}`
+      ])
+      return result
+    } catch (e) {
+      core.error('scan() error')
+      throw e
+    }
+  }
+
   private async login(): Promise<void> {
     core.debug('login()')
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,8 @@ async function run(): Promise<void> {
 
     await docker.build(target)
 
+    await docker.scan()
+
     await docker.push()
   } catch (error) {
     core.error(error.toString())


### PR DESCRIPTION
image_assembly_line の中で push する前に trivy を使って脆弱性スキャンを実施します。
この PR では CI を落とすところはまだやっていなくて、標準出力に吐くまでにしています。

### レビューポイント

* [x] このブランチをチェックアウトして `npm run test` が通ること
* [x] build-image の Actions の中でスキャン結果が出力されていること
    * https://github.com/C-FO/build-image/runs/655566138?check_suite_focus=true