### PR TITLE
Add light option to trivy

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1079,6 +1079,7 @@ class Docker {
                     throw new Error('No built image to scan');
                 }
                 const result = exec.exec('trivy', [
+                    '--light',
                     '--no-progress',
                     `${this.builtImage.imageName}:${this.builtImage.tags[0]}`
                 ]);

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -48,6 +48,7 @@ export default class Docker {
       }
 
       const result = exec.exec('trivy', [
+        '--light',
         '--no-progress',
         `${this.builtImage.imageName}:${this.builtImage.tags[0]}`
       ])


### PR DESCRIPTION
C-FO/donburi/pull/1521 に関連して image_assembly_line の trivy コマンドにも `--light` オプションを追加します。
`--light` オプションを付けると CVE の詳細が表示されなくなりますが、脆弱性データベースが非常に軽くなります。