### PR TITLE
Add severity and exit-code option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM node:12-slim AS base
+FROM alpine:latest AS base

--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -63,13 +63,19 @@ describe('Docker#scan()', () => {
 
   test('scan passed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
-    const result = await docker.scan()
+    const result = await docker.scan('CRITICAL')
+    expect(result).toEqual(0)
+  })
+
+  test('scan passed', async () => {
+    jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
+    const result = await docker.scan('HIGH')
     expect(result).toEqual(0)
   })
 
   test('scan failed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(1)
-    const result = await docker.scan()
+    const result = await docker.scan('CRITICAL')
     expect(result).toEqual(1)
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   target:
     description: 'make target'
     default: 'build'
+  severity_level:
+    description: 'severities of vulnerabilities to be displayed'
+    default: 'CRITICAL' # Available values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
   no_push:
     description: 'set true if you do not want to push image to ECR'
     default: ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -1080,14 +1080,16 @@ class Docker {
                 if (!this.builtImage) {
                     throw new Error('No built image to scan');
                 }
-                if (severityLevel.indexOf('CRITICAL') === -1) {
+                if (!severityLevel.includes('CRITICAL')) {
                     severityLevel = `CRITICAL,${severityLevel}`;
                 }
                 const result = exec.exec('trivy', [
                     '--light',
                     '--no-progress',
-                    '--exit-code', '1',
-                    '--severity', severityLevel,
+                    '--exit-code',
+                    '1',
+                    '--severity',
+                    severityLevel,
                     `${this.builtImage.imageName}:${this.builtImage.tags[0]}`
                 ]);
                 return result;

--- a/dist/index.js
+++ b/dist/index.js
@@ -991,12 +991,14 @@ function run() {
             core.debug(`target: ${target}`);
             const imageName = core.getInput('image_name');
             core.debug(`image_name: ${imageName}`);
+            const severityLevel = core.getInput('severity_level');
+            core.debug(`severity_level: ${severityLevel.toString()}`);
             const noPush = core.getInput('no_push');
             core.debug(`no_push: ${noPush.toString()}`);
             const docker = new docker_1.default(registry, imageName);
             core.debug(`docker: ${docker.toString()}`);
             yield docker.build(target);
-            yield docker.scan();
+            yield docker.scan(severityLevel);
             if (noPush.toString() === 'true') {
                 core.info('no_push: true');
             }
@@ -1072,14 +1074,15 @@ class Docker {
             }
         });
     }
-    scan() {
+    scan(severityLevel) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
                 if (!this.builtImage) {
                     throw new Error('No built image to scan');
                 }
-                // Available values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
-                let severityLevel = 'HIGH,CRITICAL';
+                if (severityLevel.indexOf('CRITICAL') === -1) {
+                    severityLevel = `CRITICAL,${severityLevel}`;
+                }
                 const result = exec.exec('trivy', [
                     '--light',
                     '--no-progress',

--- a/dist/index.js
+++ b/dist/index.js
@@ -1078,9 +1078,13 @@ class Docker {
                 if (!this.builtImage) {
                     throw new Error('No built image to scan');
                 }
+                // Available values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
+                let severityLevel = 'HIGH,CRITICAL';
                 const result = exec.exec('trivy', [
                     '--light',
                     '--no-progress',
+                    '--exit-code', '1',
+                    '--severity', severityLevel,
                     `${this.builtImage.imageName}:${this.builtImage.tags[0]}`
                 ]);
                 return result;

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -47,15 +47,17 @@ export default class Docker {
         throw new Error('No built image to scan')
       }
 
-      if (severityLevel.indexOf('CRITICAL') === -1) {
+      if (!severityLevel.includes('CRITICAL')) {
         severityLevel = `CRITICAL,${severityLevel}`
       }
 
       const result = exec.exec('trivy', [
         '--light',
         '--no-progress',
-        '--exit-code', '1',
-        '--severity', severityLevel,
+        '--exit-code',
+        '1',
+        '--severity',
+        severityLevel,
         `${this.builtImage.imageName}:${this.builtImage.tags[0]}`
       ])
       return result

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -41,14 +41,15 @@ export default class Docker {
     }
   }
 
-  async scan(): Promise<number> {
+  async scan(severityLevel: string): Promise<number> {
     try {
       if (!this.builtImage) {
         throw new Error('No built image to scan')
       }
 
-      // Available values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
-      let severityLevel = 'HIGH,CRITICAL'
+      if (severityLevel.indexOf('CRITICAL') === -1) {
+        severityLevel = `CRITICAL,${severityLevel}`
+      }
 
       const result = exec.exec('trivy', [
         '--light',

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -47,9 +47,14 @@ export default class Docker {
         throw new Error('No built image to scan')
       }
 
+      // Available values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
+      let severityLevel = 'HIGH,CRITICAL'
+
       const result = exec.exec('trivy', [
         '--light',
         '--no-progress',
+        '--exit-code', '1',
+        '--severity', severityLevel,
         `${this.builtImage.imageName}:${this.builtImage.tags[0]}`
       ])
       return result

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,9 @@ async function run(): Promise<void> {
     const imageName = core.getInput('image_name')
     core.debug(`image_name: ${imageName}`)
 
+    const severityLevel = core.getInput('severity_level')
+    core.debug(`severity_level: ${severityLevel.toString()}`)
+
     const noPush = core.getInput('no_push')
     core.debug(`no_push: ${noPush.toString()}`)
 
@@ -27,7 +30,7 @@ async function run(): Promise<void> {
 
     await docker.build(target)
 
-    await docker.scan()
+    await docker.scan(severityLevel)
 
     if (noPush.toString() === 'true') {
       core.info('no_push: true')


### PR DESCRIPTION
Trivy の脆弱性スキャンで Critical, High な CVE が見つかったときに exit code 1 を返して CI を落とします。

実際の検証結果は次の URL を確認してください 👇 

* Critical, High が見つかったとき
  * https://github.com/C-FO/build-image/runs/669913571?check_suite_focus=true
* Critical, High が見つからなかったとき（上で見つかった CVE を `.trivyignore` に追加）
  * https://github.com/C-FO/build-image/runs/670289953?check_suite_focus=true