### PR TITLE
エラーハンドリングクラスの追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ node_modules
 tmp
 tools
 dist
+src

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,3 @@ node_modules
 tmp
 tools
 dist
-src

--- a/dist/index.js
+++ b/dist/index.js
@@ -1034,16 +1034,16 @@ function run() {
         }
         catch (e) {
             if (e instanceof error_1.BuildError) {
-                console.error('image build error');
+                core.error('image build error');
             }
             else if (e instanceof error_1.ScanError) {
-                console.error('image scan error');
+                core.error('image scan error');
             }
             else if (e instanceof error_1.PushError) {
-                console.error('ecr push error');
+                core.error('ecr push error');
             }
             else {
-                console.error('unknown error');
+                core.error('unknown error');
             }
             core.setFailed(e);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -940,32 +940,23 @@ class ExecState extends events.EventEmitter {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-class baseError extends Error {
+class BaseError extends Error {
     constructor(e) {
         super(e);
         this.name = new.target.name;
         Object.setPrototypeOf(this, new.target.prototype);
     }
 }
-exports.baseError = baseError;
-class buildError extends baseError {
-    constructor(e) {
-        super(e);
-    }
+exports.BaseError = BaseError;
+class BuildError extends BaseError {
 }
-exports.buildError = buildError;
-class scanError extends baseError {
-    constructor(e) {
-        super(e);
-    }
+exports.BuildError = BuildError;
+class ScanError extends BaseError {
 }
-exports.scanError = scanError;
-class pushError extends baseError {
-    constructor(e) {
-        super(e);
-    }
+exports.ScanError = ScanError;
+class PushError extends BaseError {
 }
-exports.pushError = pushError;
+exports.PushError = PushError;
 
 
 /***/ }),
@@ -1042,13 +1033,13 @@ function run() {
             }
         }
         catch (e) {
-            if (e instanceof error_1.buildError) {
+            if (e instanceof error_1.BuildError) {
                 console.error('image build error');
             }
-            else if (e instanceof error_1.scanError) {
+            else if (e instanceof error_1.ScanError) {
                 console.error('image scan error');
             }
-            else if (e instanceof error_1.pushError) {
+            else if (e instanceof error_1.PushError) {
                 console.error('ecr push error');
             }
             else {
@@ -1117,7 +1108,7 @@ class Docker {
             }
             catch (e) {
                 core.debug('build() error');
-                throw new error_1.buildError(e);
+                throw new error_1.BuildError(e);
             }
         });
     }
@@ -1136,7 +1127,7 @@ class Docker {
             }
             catch (e) {
                 core.error('scan() error');
-                throw new error_1.scanError(e);
+                throw new error_1.ScanError(e);
             }
         });
     }
@@ -1203,7 +1194,7 @@ class Docker {
             }
             catch (e) {
                 core.error('push() error');
-                throw new error_1.pushError(e);
+                throw new error_1.PushError(e);
             }
         });
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -934,6 +934,42 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
+/***/ 25:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+class baseError extends Error {
+    constructor(e) {
+        super(e);
+        this.name = new.target.name;
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+}
+exports.baseError = baseError;
+class buildError extends baseError {
+    constructor(e) {
+        super(e);
+    }
+}
+exports.buildError = buildError;
+class scanError extends baseError {
+    constructor(e) {
+        super(e);
+    }
+}
+exports.scanError = scanError;
+class pushError extends baseError {
+    constructor(e) {
+        super(e);
+    }
+}
+exports.pushError = pushError;
+
+
+/***/ }),
+
 /***/ 87:
 /***/ (function(module) {
 
@@ -975,6 +1011,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const docker_1 = __importDefault(__webpack_require__(231));
+const error_1 = __webpack_require__(25);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -1004,9 +1041,20 @@ function run() {
                 yield docker.push();
             }
         }
-        catch (error) {
-            core.error(error.toString());
-            core.setFailed(error.message);
+        catch (e) {
+            if (e instanceof error_1.buildError) {
+                console.error('image build error');
+            }
+            else if (e instanceof error_1.scanError) {
+                console.error('image scan error');
+            }
+            else if (e instanceof error_1.pushError) {
+                console.error('ecr push error');
+            }
+            else {
+                console.error('unknown error');
+            }
+            core.setFailed(e);
         }
     });
 }
@@ -1040,6 +1088,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const exec = __importStar(__webpack_require__(986));
 const docker_util_1 = __webpack_require__(708);
+const error_1 = __webpack_require__(25);
 // import {spawnSync, SpawnSyncReturns} from 'child_process'
 class Docker {
     constructor(registry, imageName) {
@@ -1068,7 +1117,7 @@ class Docker {
             }
             catch (e) {
                 core.debug('build() error');
-                throw e;
+                throw new error_1.buildError(e);
             }
         });
     }
@@ -1087,7 +1136,7 @@ class Docker {
             }
             catch (e) {
                 core.error('scan() error');
-                throw e;
+                throw new error_1.scanError(e);
             }
         });
     }
@@ -1154,7 +1203,7 @@ class Docker {
             }
             catch (e) {
                 core.error('push() error');
-                throw e;
+                throw new error_1.pushError(e);
             }
         });
     }

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as im from '@actions/exec/lib/interfaces'
 import {latestBuiltImage, noBuiltImage, imageTag} from './docker-util'
-import {buildError, scanError, pushError} from './error'
+import {BuildError, ScanError, PushError} from './error'
 
 // import {spawnSync, SpawnSyncReturns} from 'child_process'
 
@@ -38,7 +38,7 @@ export default class Docker {
       return this.update()
     } catch (e) {
       core.debug('build() error')
-      throw new buildError(e)
+      throw new BuildError(e)
     }
   }
 
@@ -56,7 +56,7 @@ export default class Docker {
       return result
     } catch (e) {
       core.error('scan() error')
-      throw new scanError(e)
+      throw new ScanError(e)
     }
   }
 
@@ -128,7 +128,7 @@ export default class Docker {
       return result
     } catch (e) {
       core.error('push() error')
-      throw new pushError(e)
+      throw new PushError(e)
     }
   }
 

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as im from '@actions/exec/lib/interfaces'
 import {latestBuiltImage, noBuiltImage, imageTag} from './docker-util'
+import {buildError, scanError, pushError} from './error'
 
 // import {spawnSync, SpawnSyncReturns} from 'child_process'
 
@@ -37,7 +38,7 @@ export default class Docker {
       return this.update()
     } catch (e) {
       core.debug('build() error')
-      throw e
+      throw new buildError(e)
     }
   }
 
@@ -55,7 +56,7 @@ export default class Docker {
       return result
     } catch (e) {
       core.error('scan() error')
-      throw e
+      throw new scanError(e)
     }
   }
 
@@ -127,7 +128,7 @@ export default class Docker {
       return result
     } catch (e) {
       core.error('push() error')
-      throw e
+      throw new pushError(e)
     }
   }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,8 +1,8 @@
 export class BaseError extends Error {
   constructor(e?: string) {
-    super(e);
-    this.name = new.target.name;
-    Object.setPrototypeOf(this, new.target.prototype);
+    super(e)
+    this.name = new.target.name
+    Object.setPrototypeOf(this, new.target.prototype)
   }
 }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,25 @@
+export class baseError extends Error {
+  constructor(e?: string) {
+    super(e);
+    this.name = new.target.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class buildError extends baseError {
+  constructor(e?: string) {
+    super(e)
+  }
+}
+
+export class scanError extends baseError {
+  constructor(e?: string) {
+    super(e)
+  }
+}
+
+export class pushError extends baseError {
+  constructor(e?: string) {
+    super(e)
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,4 +1,4 @@
-export class baseError extends Error {
+export class BaseError extends Error {
   constructor(e?: string) {
     super(e);
     this.name = new.target.name;
@@ -6,20 +6,8 @@ export class baseError extends Error {
   }
 }
 
-export class buildError extends baseError {
-  constructor(e?: string) {
-    super(e)
-  }
-}
+export class BuildError extends BaseError {}
 
-export class scanError extends baseError {
-  constructor(e?: string) {
-    super(e)
-  }
-}
+export class ScanError extends BaseError {}
 
-export class pushError extends baseError {
-  constructor(e?: string) {
-    super(e)
-  }
-}
+export class PushError extends BaseError {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import Docker from './docker'
-import {buildError, scanError, pushError} from './error'
+import {BuildError, ScanError, PushError} from './error'
 
 async function run(): Promise<void> {
   try {
@@ -36,11 +36,11 @@ async function run(): Promise<void> {
       await docker.push()
     }
   } catch (e) {
-    if (e instanceof buildError) {
+    if (e instanceof BuildError) {
       console.error('image build error');
-    } else if (e instanceof scanError) {
+    } else if (e instanceof ScanError) {
       console.error('image scan error');
-    } else if (e instanceof pushError) {
+    } else if (e instanceof PushError) {
       console.error('ecr push error');
     } else {
       console.error('unknown error');

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,13 +37,13 @@ async function run(): Promise<void> {
     }
   } catch (e) {
     if (e instanceof BuildError) {
-      console.error('image build error');
+      core.error('image build error')
     } else if (e instanceof ScanError) {
-      console.error('image scan error');
+      core.error('image scan error')
     } else if (e instanceof PushError) {
-      console.error('ecr push error');
+      core.error('ecr push error')
     } else {
-      console.error('unknown error');
+      core.error('unknown error')
     }
     core.setFailed(e)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import * as core from '@actions/core'
 import Docker from './docker'
+import {buildError, scanError, pushError} from './error'
 
 async function run(): Promise<void> {
   try {
@@ -34,9 +35,17 @@ async function run(): Promise<void> {
     } else {
       await docker.push()
     }
-  } catch (error) {
-    core.error(error.toString())
-    core.setFailed(error.message)
+  } catch (e) {
+    if (e instanceof buildError) {
+      console.error('image build error');
+    } else if (e instanceof scanError) {
+      console.error('image scan error');
+    } else if (e instanceof pushError) {
+      console.error('ecr push error');
+    } else {
+      console.error('unknown error');
+    }
+    core.setFailed(e)
   }
 }
 


### PR DESCRIPTION
## 概要
エラーハンドリングの実装

## 変更内容
main の catch 節でエラーハンドリングができるようにするため下記を追加しました
1. Error を BaseError で継承させた
1. ハンドリングさせたい Class の catch 節にて `throw new HogeError(e) extends BaseError` とした
1. main の catch において 上記 2. を補足するため、instanceof で if文 を追加した

## この PR で実現したいこと
main の catch 節でエラーハンドリングができるようになることにより
各 step 毎に通知内容を変更することが可能になります

## 事前検証結果
- 正常系
  - https://github.com/C-FO/build-image/runs/673963714?check_suite_focus=true
- 異常系
  - BuildError
    - https://github.com/C-FO/build-image/runs/673864520?check_suite_focus=true
  - ScanError
    - https://github.com/C-FO/build-image/runs/673888462?check_suite_focus=true
  - PushError
    - https://github.com/C-FO/build-image/runs/673916122?check_suite_focus=true

## review check list
- [x] test がすべて通っていること