### PR TITLE
action内で作ったイメージや github_run_id をoutput に保存する

### DIFF
--- a/__tests__/deliver.test.ts
+++ b/__tests__/deliver.test.ts
@@ -1,0 +1,23 @@
+import * as core from '@actions/core'
+import * as deliver from '../src/deliver'
+import {DockerImage} from '../src/docker'
+
+describe('setDeliver()', () => {
+  test('throw error if there is no built image', async () => {
+    const image = {
+      imageID: '1234567890',
+      imageName: '1234567890.dkr.ecr.ap-northeast-1.amazonaws.com/test/app'
+    } as DockerImage
+    const gitHubRunID = '0987654321'
+
+    const setOutput = jest.spyOn(core, 'setOutput').mockImplementation(() => {})
+
+    await deliver.setDelivery({
+      dockerImage: image,
+      gitHubRunID: gitHubRunID
+    })
+    expect(setOutput).toHaveBeenCalledWith('built_image_name', image.imageName)
+    expect(setOutput).toHaveBeenCalledWith('built_image_id', image.imageID)
+    expect(setOutput).toHaveBeenCalledWith('git_hub_run_id', gitHubRunID)
+  })
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -1003,9 +1003,11 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const docker_1 = __importDefault(__webpack_require__(231));
 const error_1 = __webpack_require__(25);
+const exec = __importStar(__webpack_require__(986));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            yield exec.exec('env');
             // REGISTRY_NAME はユーザー側から渡せない様にする
             const registry = process.env.REGISTRY_NAME;
             if (!registry) {
@@ -1033,6 +1035,8 @@ function run() {
             else {
                 yield docker.push();
             }
+            core.setOutput('generated_name', 'testdocker/image');
+            core.setOutput('generated_id', '1234abcDEF');
         }
         catch (e) {
             if (e instanceof error_1.BuildError) {

--- a/src/deliver.ts
+++ b/src/deliver.ts
@@ -1,0 +1,13 @@
+import * as core from '@actions/core'
+import {DockerImage} from './docker'
+
+export interface Delivery {
+  dockerImage: DockerImage
+  gitHubRunID: string
+}
+
+export async function setDelivery(delivery: Delivery): Promise<void> {
+  core.setOutput('built_image_name', delivery.dockerImage.imageName)
+  core.setOutput('built_image_id', delivery.dockerImage.imageID)
+  core.setOutput('git_hub_run_id', delivery.gitHubRunID)
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,11 @@
 import * as core from '@actions/core'
 import Docker from './docker'
 import {BuildError, ScanError, PushError} from './error'
+import * as exec from '@actions/exec'
 
 async function run(): Promise<void> {
   try {
+    await exec.exec('env')
     // REGISTRY_NAME はユーザー側から渡せない様にする
     const registry: string | undefined = process.env.REGISTRY_NAME
     if (!registry) {
@@ -38,6 +40,9 @@ async function run(): Promise<void> {
     } else {
       await docker.push()
     }
+
+    core.setOutput('generated_name', 'testdocker/image')
+    core.setOutput('generated_id', '1234abcDEF')
   } catch (e) {
     if (e instanceof BuildError) {
       core.error('image build error')

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -1,9 +1,0 @@
-export async function wait(milliseconds: number): Promise<string> {
-  return new Promise(resolve => {
-    if (isNaN(milliseconds)) {
-      throw new Error('milliseconds not a number')
-    }
-
-    setTimeout(() => resolve('done!'), milliseconds)
-  })
-}


### PR DESCRIPTION
https://jira-freee.atlassian.net/jira/software/projects/CONTAINER/boards/630?selectedIssue=CONTAINER-92

以下の情報を`setOutput()`で保存するようにしました。
image ID
image repository
workflow の ID

workflow の ID は job の ID が分からず、GITHUB_RUN_ID で workflow の ID が取得出来ることが分かったのでそれを入れてみました

実際に走った様子はこちら
```
::set-output name=built_image_name,::build-image/app
##[debug]='build-image/app'
::set-output name=built_image_id,::87fb29333ac6
##[debug]='87fb29333ac6'
::set-output name=git_hub_run_id,::110139344
##[debug]='110139344'
```

実際の workflow file はこちらです