### PR TITLE
Add scan_exit_code input

### DIFF
--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -63,19 +63,19 @@ describe('Docker#scan()', () => {
 
   test('scan passed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
-    const result = await docker.scan('CRITICAL')
+    const result = await docker.scan('CRITICAL', '0')
     expect(result).toEqual(0)
   })
 
   test('scan passed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
-    const result = await docker.scan('HIGH')
+    const result = await docker.scan('HIGH', '0')
     expect(result).toEqual(0)
   })
 
   test('scan failed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(1)
-    const result = await docker.scan('CRITICAL')
+    const result = await docker.scan('CRITICAL', '1')
     expect(result).toEqual(1)
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   severity_level:
     description: 'severities of vulnerabilities to be displayed'
     default: 'CRITICAL' # Available values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
+  scan_exit_code:
+    description: 'Exit code when vulnerabilities were found'
+    default: '0'
   no_push:
     description: 'set true if you do not want to push image to ECR'
     default: ''

--- a/dist/index.js
+++ b/dist/index.js
@@ -1025,12 +1025,14 @@ function run() {
             core.debug(`image_name: ${imageName}`);
             const severityLevel = core.getInput('severity_level');
             core.debug(`severity_level: ${severityLevel.toString()}`);
+            const scanExitCode = core.getInput('scan_exit_code');
+            core.debug(`scan_exit_code: ${scanExitCode.toString()}`);
             const noPush = core.getInput('no_push');
             core.debug(`no_push: ${noPush.toString()}`);
             const docker = new docker_1.default(registry, imageName);
             core.debug(`docker: ${docker.toString()}`);
             yield docker.build(target);
-            yield docker.scan(severityLevel);
+            yield docker.scan(severityLevel, scanExitCode);
             if (noPush.toString() === 'true') {
                 core.info('no_push: true');
             }
@@ -1127,7 +1129,7 @@ class Docker {
             }
         });
     }
-    scan(severityLevel) {
+    scan(severityLevel, scanExitCode) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
                 if (!this._builtImage) {
@@ -1140,7 +1142,7 @@ class Docker {
                     '--light',
                     '--no-progress',
                     '--exit-code',
-                    '1',
+                    scanExitCode,
                     '--severity',
                     severityLevel,
                     `${this._builtImage.imageName}:${this._builtImage.tags[0]}`

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -46,7 +46,7 @@ export default class Docker {
     }
   }
 
-  async scan(severityLevel: string): Promise<number> {
+  async scan(severityLevel: string, scanExitCode: string): Promise<number> {
     try {
       if (!this._builtImage) {
         throw new Error('No built image to scan')
@@ -60,7 +60,7 @@ export default class Docker {
         '--light',
         '--no-progress',
         '--exit-code',
-        '1',
+        scanExitCode,
         '--severity',
         severityLevel,
         `${this._builtImage.imageName}:${this._builtImage.tags[0]}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,9 @@ async function run(): Promise<void> {
     const severityLevel = core.getInput('severity_level')
     core.debug(`severity_level: ${severityLevel.toString()}`)
 
+    const scanExitCode = core.getInput('scan_exit_code')
+    core.debug(`scan_exit_code: ${scanExitCode.toString()}`)
+
     const noPush = core.getInput('no_push')
     core.debug(`no_push: ${noPush.toString()}`)
 
@@ -32,7 +35,7 @@ async function run(): Promise<void> {
 
     await docker.build(target)
 
-    await docker.scan(severityLevel)
+    await docker.scan(severityLevel, scanExitCode)
 
     if (noPush.toString() === 'true') {
       core.info('no_push: true')


### PR DESCRIPTION
コンテナに脆弱性が見つかったとき、通知だけして CI を落とさないようにしたいということになりました。
action.yml で `scan_exit_code` のインプットを受け取れるようにすることで、開発者が CI を落とすかどうか選択できるようにします（デフォルトは `0`）。