### PR TITLE
Change trivy output

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,16 @@ export interface VulnerabilityIssue {
   name: string
   cve: string
 }
+
+export interface Vulnerability {
+  Target: string
+  Vulnerabilities: CVE[] | null
+}
+
+interface CVE {
+  VulnerabilityID: string
+  PkgName: string
+  InstalledVersion: string
+  FixedVersion: string
+  Severity: string
+}


### PR DESCRIPTION
Trivy のスキャン結果を Slack に通知したり S3 にアップロードする際、デフォルトのテーブル表示では扱いにくいです。
スキャン結果を JSON で受け取ることで、後続の処理で扱いやすいようにします。

## 📝 レビューポイント

- [x] `npm run test`, `npm run lint` が通る
- [x] Action の標準出力に "Target: build-image/app:latest (alpine 3.11.6)" が出力されている
  - https://github.com/C-FO/build-image/runs/726662885