### PR TITLE
Docker Engine API を使って Image の list を取得するようにする

### DIFF
--- a/__tests__/docker-util.test.ts
+++ b/__tests__/docker-util.test.ts
@@ -1,34 +1,103 @@
 import * as dockerUtil from '../src/docker-util'
 import * as exec from '@actions/exec'
+import axios from 'axios'
 
 describe('latestBuiltImage()', () => {
-  test('returns latest built image', async () => {
-    const imageName = 'image_assembly_line/debug'
-    const imageID = '63997a1b0d08'
-    const imageLs = jest
-      .spyOn(dockerUtil, 'imageLs')
-      .mockImplementation(() =>
-        Promise.resolve([
-          `${imageName},latest,${imageID}`,
-          `${imageName},v.1.1,${imageID}`,
-          'image_assembly_line/debug,1.0,bb86086cce7c'
-        ])
-      )
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
 
-    const builtImage = await dockerUtil.latestBuiltImage(imageName)
-    expect(imageLs).toHaveBeenCalledWith(imageName)
-    expect(builtImage.imageID).toEqual(imageID)
-    expect(builtImage.imageName).toEqual(imageName)
-    expect(builtImage.tags).toEqual(['latest', 'v.1.1']) // store tags for same ID
+  test('returns latest built image', async () => {
+    const mock = jest.spyOn(axios, 'get').mockResolvedValueOnce(DOCKRE_RESPONSE)
+
+    const builtImage = await dockerUtil.latestBuiltImage(BUILT_IMAGE_NAME)
+    expect(builtImage.imageID).toEqual(BUILT_IMAGE_ID)
+    expect(builtImage.imageName).toEqual(BUILT_IMAGE_NAME)
+    expect(builtImage.tags).toContain('1.11') // store tags for same ID
   })
 
   test('throw error if there is no built image', async () => {
-    const imageName = 'image_assembly_line/debug'
+    const imageName = 'noimages/app'
     const imageLs = jest
-      .spyOn(dockerUtil, 'imageLs')
+      .spyOn(dockerUtil, 'dockerImageLs')
       .mockImplementation(() => Promise.resolve([]))
 
     const result = dockerUtil.latestBuiltImage(imageName)
     await expect(result).rejects.toThrowError()
   })
 })
+
+describe('imageList()', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('when there is some specified images', async () => {
+    const mock = jest.spyOn(axios, 'get').mockResolvedValueOnce(DOCKRE_RESPONSE)
+    const imageList = await dockerUtil.dockerImageLs(BUILT_IMAGE_NAME)
+
+    expect(mock).toHaveBeenCalledWith('http:/v1.39/images/json', {
+      params: {filter: BUILT_IMAGE_NAME},
+      socketPath: '/var/run/docker.sock'
+    })
+
+    // sorted
+    const latestImageCreated = imageList[0].Created as number
+    for (const image of imageList) {
+      const created = image.Created as number
+      expect(latestImageCreated >= created).toBeTruthy()
+
+      for (const tag of image.RepoTags as string[]) {
+        expect(tag.startsWith(BUILT_IMAGE_NAME)).toBeTruthy()
+      }
+    }
+  })
+
+  test('when there is NO any specified images', async () => {
+    const mock = jest.spyOn(axios, 'get').mockResolvedValueOnce({data: []})
+
+    const imageList = await dockerUtil.dockerImageLs('noimages/app')
+    expect(imageList.length).toBe(0)
+  })
+})
+
+const BUILT_IMAGE_NAME = 'image_assembly_line/debug'
+const BUILT_IMAGE_ID =
+  'sha256:446592c964a64e32631e6c8a6a6cfdf7f5efa26127171a72dc82f14736ba0530'
+
+const DOCKRE_RESPONSE = {
+  status: 200,
+  data: [
+    {
+      Containers: -1,
+      Created: 1590110015,
+      Id: BUILT_IMAGE_ID,
+      Labels: null,
+      ParentId:
+        'sha256:0d8129317a9f8bf07521948555d3136ae96efc7cae2d7932da3d1e55db47c2ae',
+      RepoDigests: null,
+      RepoTags: [
+        'image_assembly_line/debug:1.11',
+        'image_assembly_line/debug:dev',
+        'image_assembly_line/debug:latest'
+      ],
+      SharedSize: -1,
+      Size: 1199289384,
+      VirtualSize: 1199289384
+    },
+    {
+      Containers: -1,
+      Created: 1589195609,
+      Id:
+        'sha256:021bf420eb2012013108dc0dced3b6d82f99db61656a38ab7600917efe2e64c1',
+      Labels: null,
+      ParentId:
+        'sha256:fa021e46798bb12114119afed83683d22c5379bde9446571af77d40ebf75934d',
+      RepoDigests: null,
+      RepoTags: ['image_assembly_line/debug:1.9'],
+      SharedSize: -1,
+      Size: 1158899521,
+      VirtualSize: 1158899521
+    }
+  ]
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -3363,7 +3363,7 @@ module.exports = {"version":"2.0","metadata":{"apiVersion":"2014-06-30","endpoin
 /* 59 */
 /***/ (function(module) {
 
-module.exports = {"_args":[["@slack/web-api@5.9.0","/Users/sakai-manabu/repository/image_assembly_line"]],"_from":"@slack/web-api@5.9.0","_id":"@slack/web-api@5.9.0","_inBundle":false,"_integrity":"sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==","_location":"/@slack/web-api","_phantomChildren":{"asynckit":"0.4.0","combined-stream":"1.0.8","mime-types":"2.1.25"},"_requested":{"type":"version","registry":true,"raw":"@slack/web-api@5.9.0","name":"@slack/web-api","escapedName":"@slack%2fweb-api","scope":"@slack","rawSpec":"5.9.0","saveSpec":null,"fetchSpec":"5.9.0"},"_requiredBy":["/@slack/bolt","/@slack/oauth"],"_resolved":"https://registry.npmjs.org/@slack/web-api/-/web-api-5.9.0.tgz","_spec":"5.9.0","_where":"/Users/sakai-manabu/repository/image_assembly_line","author":{"name":"Slack Technologies, Inc."},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.2.1","@types/is-stream":"^1.1.0","@types/node":">=8.9.0","@types/p-queue":"^2.3.2","axios":"^0.19.0","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^2.4.2","p-retry":"^4.0.0"},"description":"Official library for using the Slack Platform's Web API","devDependencies":{"@aoberoi/capture-console":"^1.1.0","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^8.0.3","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^3.3.3333"},"engines":{"node":">= 8.9.0","npm":">= 5.5.1"},"files":["dist/**/*"],"homepage":"https://slack.dev/node-slack-sdk/web-api","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"license":"MIT","main":"dist/index.js","name":"@slack/web-api","publishConfig":{"access":"public"},"repository":{"type":"git","url":"git+https://github.com/slackapi/node-slack-sdk.git"},"scripts":{"build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","coverage":"codecov -F webapi --root=$PWD","lint":"tslint --project .","prepare":"npm run build","test":"npm run build && nyc mocha --config .mocharc.json src/*.spec.js"},"types":"./dist/index.d.ts","version":"5.9.0"};
+module.exports = {"_from":"@slack/web-api@^5.8.0","_id":"@slack/web-api@5.9.0","_inBundle":false,"_integrity":"sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==","_location":"/@slack/web-api","_phantomChildren":{"asynckit":"0.4.0","combined-stream":"1.0.8","mime-types":"2.1.25"},"_requested":{"type":"range","registry":true,"raw":"@slack/web-api@^5.8.0","name":"@slack/web-api","escapedName":"@slack%2fweb-api","scope":"@slack","rawSpec":"^5.8.0","saveSpec":null,"fetchSpec":"^5.8.0"},"_requiredBy":["/@slack/bolt"],"_resolved":"https://registry.npmjs.org/@slack/web-api/-/web-api-5.9.0.tgz","_shasum":"13ce1eecc405c3972e6037d54338344d7859a3b5","_spec":"@slack/web-api@^5.8.0","_where":"/Users/kaku-junichi/Workspace/image_assembly_line/node_modules/@slack/bolt","author":{"name":"Slack Technologies, Inc."},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"bundleDependencies":false,"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.2.1","@types/is-stream":"^1.1.0","@types/node":">=8.9.0","@types/p-queue":"^2.3.2","axios":"^0.19.0","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^2.4.2","p-retry":"^4.0.0"},"deprecated":false,"description":"Official library for using the Slack Platform's Web API","devDependencies":{"@aoberoi/capture-console":"^1.1.0","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^8.0.3","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^3.3.3333"},"engines":{"node":">= 8.9.0","npm":">= 5.5.1"},"files":["dist/**/*"],"homepage":"https://slack.dev/node-slack-sdk/web-api","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"license":"MIT","main":"dist/index.js","name":"@slack/web-api","publishConfig":{"access":"public"},"repository":{"type":"git","url":"git+https://github.com/slackapi/node-slack-sdk.git"},"scripts":{"build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","coverage":"codecov -F webapi --root=$PWD","lint":"tslint --project .","prepare":"npm run build","test":"npm run build && nyc mocha --config .mocharc.json src/*.spec.js"},"types":"./dist/index.d.ts","version":"5.9.0"};
 
 /***/ }),
 /* 60 */,
@@ -9531,7 +9531,7 @@ module.exports = require("assert");
 /* 361 */
 /***/ (function(module) {
 
-module.exports = {"_args":[["axios@0.19.2","/Users/sakai-manabu/repository/image_assembly_line"]],"_from":"axios@0.19.2","_id":"axios@0.19.2","_inBundle":false,"_integrity":"sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==","_location":"/axios","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"axios@0.19.2","name":"axios","escapedName":"axios","rawSpec":"0.19.2","saveSpec":null,"fetchSpec":"0.19.2"},"_requiredBy":["/@slack/bolt","/@slack/web-api"],"_resolved":"https://registry.npmjs.org/axios/-/axios-0.19.2.tgz","_spec":"0.19.2","_where":"/Users/sakai-manabu/repository/image_assembly_line","author":{"name":"Matt Zabriskie"},"browser":{"./lib/adapters/http.js":"./lib/adapters/xhr.js"},"bugs":{"url":"https://github.com/axios/axios/issues"},"bundlesize":[{"path":"./dist/axios.min.js","threshold":"5kB"}],"dependencies":{"follow-redirects":"1.5.10"},"description":"Promise based HTTP client for the browser and node.js","devDependencies":{"bundlesize":"^0.17.0","coveralls":"^3.0.0","es6-promise":"^4.2.4","grunt":"^1.0.2","grunt-banner":"^0.6.0","grunt-cli":"^1.2.0","grunt-contrib-clean":"^1.1.0","grunt-contrib-watch":"^1.0.0","grunt-eslint":"^20.1.0","grunt-karma":"^2.0.0","grunt-mocha-test":"^0.13.3","grunt-ts":"^6.0.0-beta.19","grunt-webpack":"^1.0.18","istanbul-instrumenter-loader":"^1.0.0","jasmine-core":"^2.4.1","karma":"^1.3.0","karma-chrome-launcher":"^2.2.0","karma-coverage":"^1.1.1","karma-firefox-launcher":"^1.1.0","karma-jasmine":"^1.1.1","karma-jasmine-ajax":"^0.1.13","karma-opera-launcher":"^1.0.0","karma-safari-launcher":"^1.0.0","karma-sauce-launcher":"^1.2.0","karma-sinon":"^1.0.5","karma-sourcemap-loader":"^0.3.7","karma-webpack":"^1.7.0","load-grunt-tasks":"^3.5.2","minimist":"^1.2.0","mocha":"^5.2.0","sinon":"^4.5.0","typescript":"^2.8.1","url-search-params":"^0.10.0","webpack":"^1.13.1","webpack-dev-server":"^1.14.1"},"homepage":"https://github.com/axios/axios","keywords":["xhr","http","ajax","promise","node"],"license":"MIT","main":"index.js","name":"axios","repository":{"type":"git","url":"git+https://github.com/axios/axios.git"},"scripts":{"build":"NODE_ENV=production grunt build","coveralls":"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js","examples":"node ./examples/server.js","fix":"eslint --fix lib/**/*.js","postversion":"git push && git push --tags","preversion":"npm test","start":"node ./sandbox/server.js","test":"grunt test && bundlesize","version":"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json"},"typings":"./index.d.ts","version":"0.19.2"};
+module.exports = {"_from":"axios","_id":"axios@0.19.2","_inBundle":false,"_integrity":"sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==","_location":"/axios","_phantomChildren":{},"_requested":{"type":"tag","registry":true,"raw":"axios","name":"axios","escapedName":"axios","rawSpec":"","saveSpec":null,"fetchSpec":"latest"},"_requiredBy":["#USER","/","/@slack/bolt","/@slack/web-api"],"_resolved":"https://registry.npmjs.org/axios/-/axios-0.19.2.tgz","_shasum":"3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27","_spec":"axios","_where":"/Users/kaku-junichi/Workspace/image_assembly_line","author":{"name":"Matt Zabriskie"},"browser":{"./lib/adapters/http.js":"./lib/adapters/xhr.js"},"bugs":{"url":"https://github.com/axios/axios/issues"},"bundleDependencies":false,"bundlesize":[{"path":"./dist/axios.min.js","threshold":"5kB"}],"dependencies":{"follow-redirects":"1.5.10"},"deprecated":false,"description":"Promise based HTTP client for the browser and node.js","devDependencies":{"bundlesize":"^0.17.0","coveralls":"^3.0.0","es6-promise":"^4.2.4","grunt":"^1.0.2","grunt-banner":"^0.6.0","grunt-cli":"^1.2.0","grunt-contrib-clean":"^1.1.0","grunt-contrib-watch":"^1.0.0","grunt-eslint":"^20.1.0","grunt-karma":"^2.0.0","grunt-mocha-test":"^0.13.3","grunt-ts":"^6.0.0-beta.19","grunt-webpack":"^1.0.18","istanbul-instrumenter-loader":"^1.0.0","jasmine-core":"^2.4.1","karma":"^1.3.0","karma-chrome-launcher":"^2.2.0","karma-coverage":"^1.1.1","karma-firefox-launcher":"^1.1.0","karma-jasmine":"^1.1.1","karma-jasmine-ajax":"^0.1.13","karma-opera-launcher":"^1.0.0","karma-safari-launcher":"^1.0.0","karma-sauce-launcher":"^1.2.0","karma-sinon":"^1.0.5","karma-sourcemap-loader":"^0.3.7","karma-webpack":"^1.7.0","load-grunt-tasks":"^3.5.2","minimist":"^1.2.0","mocha":"^5.2.0","sinon":"^4.5.0","typescript":"^2.8.1","url-search-params":"^0.10.0","webpack":"^1.13.1","webpack-dev-server":"^1.14.1"},"homepage":"https://github.com/axios/axios","keywords":["xhr","http","ajax","promise","node"],"license":"MIT","main":"index.js","name":"axios","repository":{"type":"git","url":"git+https://github.com/axios/axios.git"},"scripts":{"build":"NODE_ENV=production grunt build","coveralls":"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js","examples":"node ./examples/server.js","fix":"eslint --fix lib/**/*.js","postversion":"git push && git push --tags","preversion":"npm test","start":"node ./sandbox/server.js","test":"grunt test && bundlesize","version":"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json"},"typings":"./index.d.ts","version":"0.19.2"};
 
 /***/ }),
 /* 362 */,
@@ -20281,35 +20281,26 @@ var __importStar = (this && this.__importStar) || function (mod) {
     result["default"] = mod;
     return result;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const exec = __importStar(__webpack_require__(986));
 const core = __importStar(__webpack_require__(470));
-var DockerFormat;
-(function (DockerFormat) {
-    DockerFormat[DockerFormat["repository"] = 0] = "repository";
-    DockerFormat[DockerFormat["tag"] = 1] = "tag";
-    DockerFormat[DockerFormat["id"] = 2] = "id";
-})(DockerFormat || (DockerFormat = {}));
+const axios_1 = __importDefault(__webpack_require__(53));
 function latestBuiltImage(imageName) {
     return __awaiter(this, void 0, void 0, function* () {
         core.debug('latestBuiltImage()');
-        const imageLines = yield exports.imageLs(imageName);
-        if (imageLines.length < 1) {
+        const images = yield exports.dockerImageLs(imageName);
+        if (images.length < 1) {
             throw new Error('No images built');
         }
-        let builtImageName = '';
-        let builtImageID = '';
+        const latestImage = images[0];
+        const builtImageName = latestImage.RepoTags[0].split(':')[0];
+        const builtImageID = latestImage.Id;
         const tags = [];
-        for (const imageLineStr of imageLines) {
-            const imageLine = imageLineStr.split(',');
-            if (!builtImageName && !builtImageID) {
-                builtImageName = imageLine[DockerFormat.repository];
-                builtImageID = imageLine[DockerFormat.id];
-            }
-            else if (builtImageID !== imageLine[DockerFormat.id]) {
-                break;
-            }
-            tags.push(imageLine[DockerFormat.tag]);
+        for (const repoTag of latestImage.RepoTags) {
+            tags.push(repoTag.split(':').pop());
         }
         return {
             imageName: builtImageName,
@@ -20319,25 +20310,6 @@ function latestBuiltImage(imageName) {
     });
 }
 exports.latestBuiltImage = latestBuiltImage;
-function imageLs(imageName) {
-    return __awaiter(this, void 0, void 0, function* () {
-        core.debug(`imageLs(): ${imageName}`);
-        let stdout = '';
-        yield exec.exec('docker', ['image', 'ls', `--format`, '{{.Repository}},{{.Tag}},{{.ID}}'], {
-            listeners: {
-                stdout: (data) => {
-                    stdout += data.toString();
-                }
-            }
-        });
-        const result = stdout
-            .split('\n')
-            .filter(line => line.startsWith(`${imageName},`));
-        core.debug(`filtered: ${result.toString()}`);
-        return result;
-    });
-}
-exports.imageLs = imageLs;
 // Return true when check is OK
 function noBuiltImage() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -20360,12 +20332,26 @@ function imageTag(source, target) {
         yield exec.exec('docker', ['image', 'tag', source, target]);
         let result;
         do {
-            result = yield imageLs(target.split(':')[0]);
+            result = yield dockerImageLs(target);
             core.debug(`count: ${result.length.toString()}`);
         } while (result.length < 0);
     });
 }
 exports.imageTag = imageTag;
+function dockerImageLs(imageName) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Document for docker engine API.
+        // https://docs.docker.com/engine/api/v1.39/
+        const res = yield axios_1.default.get('http:/v1.39/images/json', {
+            params: { filter: imageName },
+            socketPath: '/var/run/docker.sock'
+        });
+        return res.data.sort((im1, im2) => {
+            return im2.Created - im1.Created;
+        });
+    });
+}
+exports.dockerImageLs = dockerImageLs;
 
 
 /***/ }),

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@slack/bolt": "^2.1.0",
     "@types/uuid": "^8.0.0",
     "aws-sdk": "^2.690.0",
+    "axios": "^0.19.2",
     "uuid": "^8.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# 概要
 これまで Docker Images の取得には [docker/cli](https://github.com/docker/cli) を使っていたのを、[Docker Engine](https://github.com/moby/moby) の [API v1.39](https://docs.docker.com/engine/api/v1.39/) を使うようにしました

メリットとしては以下のようなものが考えられます
* cli の出力の細かな差異によるエラーが起こりにくくなる
* ドキュメントが公開された API を使うため
* 責務が分かれて image_assembly_line のコードがシンプルになる

# やっていないこと
* `docker image ls` 以外の処理の変更

`docker tag` や `docker push` については別の PR で変更しようと思います

# 確認
build_image で動かしてみたのでそれで確認をお願いします
- [x] [build_image の Workflow](https://github.com/C-FO/build-image/actions/runs/135776910) で kakkunpakkun/image_assembly_line@refctor_to_use_docker_engine_api を指定している
- [x] 上の build_image の Workflow を Re-run して成功する 
- [x] build_image の push が成功して [ECR](https://ap-northeast-1.console.aws.amazon.com/ecr/repositories/build-image/app/?region=ap-northeast-1) で確認できる

ganesh はプロダクトに影響がないよう、`no_push: true` にして設定しているので、push以外が成功していることを確認お願いします
- [x] [ganesh の Workflow](https://github.com/C-FO/ganesh/actions/runs/135787508) で kakkunpakkun/image_assembly_line@refctor_to_use_docker_engine_api を指定している
- [x] image_assembly_line に `no_push: true` を渡している
- [x] 上の build_image の Workflow を Re-run して成功する 

# リンク
https://jira-freee.atlassian.net/browse/CONTAINER-178