### PR TITLE
Record build time

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19463,7 +19463,7 @@ function uploadVulnerability(rowJson) {
         core.debug(`JSON data: ${json}`);
         const param = {
             Bucket: bucketName,
-            Key: generateObjectKey('trivy', 'json'),
+            Key: generateObjectKey('trivy/', 'json'),
             Body: json,
             ContentType: 'application/json',
             ACL: 'bucket-owner-full-control'
@@ -19487,7 +19487,7 @@ endTime) {
         core.debug(`JSON data: ${json}`);
         const param = {
             Bucket: bucketName,
-            Key: generateObjectKey('build', 'json'),
+            Key: generateObjectKey('build/dt=', 'json'),
             Body: json,
             ContentType: 'application/json'
         };
@@ -19517,7 +19517,7 @@ function generateObjectKey(prefix, fileExtension) {
     const minute = zeroPadding(now.getMinutes(), 2);
     const second = zeroPadding(now.getSeconds(), 2);
     const objectKey = `${year}-${month}-${date}/${hour}-${minute}-${second}-${uuid_1.v4()}`;
-    return `${prefix}/${objectKey}.${fileExtension}`;
+    return `${prefix}${objectKey}.${fileExtension}`;
 }
 function zeroPadding(num, len) {
     return num.toString().padStart(len, '0');

--- a/dist/index.js
+++ b/dist/index.js
@@ -3363,7 +3363,7 @@ module.exports = {"version":"2.0","metadata":{"apiVersion":"2014-06-30","endpoin
 /* 59 */
 /***/ (function(module) {
 
-module.exports = {"_from":"@slack/web-api@^5.8.0","_id":"@slack/web-api@5.9.0","_inBundle":false,"_integrity":"sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==","_location":"/@slack/web-api","_phantomChildren":{"asynckit":"0.4.0","combined-stream":"1.0.8","mime-types":"2.1.25"},"_requested":{"type":"range","registry":true,"raw":"@slack/web-api@^5.8.0","name":"@slack/web-api","escapedName":"@slack%2fweb-api","scope":"@slack","rawSpec":"^5.8.0","saveSpec":null,"fetchSpec":"^5.8.0"},"_requiredBy":["/@slack/bolt"],"_resolved":"https://registry.npmjs.org/@slack/web-api/-/web-api-5.9.0.tgz","_shasum":"13ce1eecc405c3972e6037d54338344d7859a3b5","_spec":"@slack/web-api@^5.8.0","_where":"/Users/kaku-junichi/Workspace/image_assembly_line/node_modules/@slack/bolt","author":{"name":"Slack Technologies, Inc."},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"bundleDependencies":false,"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.2.1","@types/is-stream":"^1.1.0","@types/node":">=8.9.0","@types/p-queue":"^2.3.2","axios":"^0.19.0","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^2.4.2","p-retry":"^4.0.0"},"deprecated":false,"description":"Official library for using the Slack Platform's Web API","devDependencies":{"@aoberoi/capture-console":"^1.1.0","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^8.0.3","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^3.3.3333"},"engines":{"node":">= 8.9.0","npm":">= 5.5.1"},"files":["dist/**/*"],"homepage":"https://slack.dev/node-slack-sdk/web-api","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"license":"MIT","main":"dist/index.js","name":"@slack/web-api","publishConfig":{"access":"public"},"repository":{"type":"git","url":"git+https://github.com/slackapi/node-slack-sdk.git"},"scripts":{"build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","coverage":"codecov -F webapi --root=$PWD","lint":"tslint --project .","prepare":"npm run build","test":"npm run build && nyc mocha --config .mocharc.json src/*.spec.js"},"types":"./dist/index.d.ts","version":"5.9.0"};
+module.exports = {"_args":[["@slack/web-api@5.9.0","/Users/sakai-manabu/repository/image_assembly_line"]],"_from":"@slack/web-api@5.9.0","_id":"@slack/web-api@5.9.0","_inBundle":false,"_integrity":"sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==","_location":"/@slack/web-api","_phantomChildren":{"asynckit":"0.4.0","combined-stream":"1.0.8","mime-types":"2.1.25"},"_requested":{"type":"version","registry":true,"raw":"@slack/web-api@5.9.0","name":"@slack/web-api","escapedName":"@slack%2fweb-api","scope":"@slack","rawSpec":"5.9.0","saveSpec":null,"fetchSpec":"5.9.0"},"_requiredBy":["/@slack/bolt","/@slack/oauth"],"_resolved":"https://registry.npmjs.org/@slack/web-api/-/web-api-5.9.0.tgz","_spec":"5.9.0","_where":"/Users/sakai-manabu/repository/image_assembly_line","author":{"name":"Slack Technologies, Inc."},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.2.1","@types/is-stream":"^1.1.0","@types/node":">=8.9.0","@types/p-queue":"^2.3.2","axios":"^0.19.0","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^2.4.2","p-retry":"^4.0.0"},"description":"Official library for using the Slack Platform's Web API","devDependencies":{"@aoberoi/capture-console":"^1.1.0","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^8.0.3","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^3.3.3333"},"engines":{"node":">= 8.9.0","npm":">= 5.5.1"},"files":["dist/**/*"],"homepage":"https://slack.dev/node-slack-sdk/web-api","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"license":"MIT","main":"dist/index.js","name":"@slack/web-api","publishConfig":{"access":"public"},"repository":{"type":"git","url":"git+https://github.com/slackapi/node-slack-sdk.git"},"scripts":{"build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","coverage":"codecov -F webapi --root=$PWD","lint":"tslint --project .","prepare":"npm run build","test":"npm run build && nyc mocha --config .mocharc.json src/*.spec.js"},"types":"./dist/index.d.ts","version":"5.9.0"};
 
 /***/ }),
 /* 60 */,
@@ -9531,7 +9531,7 @@ module.exports = require("assert");
 /* 361 */
 /***/ (function(module) {
 
-module.exports = {"_from":"axios","_id":"axios@0.19.2","_inBundle":false,"_integrity":"sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==","_location":"/axios","_phantomChildren":{},"_requested":{"type":"tag","registry":true,"raw":"axios","name":"axios","escapedName":"axios","rawSpec":"","saveSpec":null,"fetchSpec":"latest"},"_requiredBy":["#USER","/","/@slack/bolt","/@slack/web-api"],"_resolved":"https://registry.npmjs.org/axios/-/axios-0.19.2.tgz","_shasum":"3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27","_spec":"axios","_where":"/Users/kaku-junichi/Workspace/image_assembly_line","author":{"name":"Matt Zabriskie"},"browser":{"./lib/adapters/http.js":"./lib/adapters/xhr.js"},"bugs":{"url":"https://github.com/axios/axios/issues"},"bundleDependencies":false,"bundlesize":[{"path":"./dist/axios.min.js","threshold":"5kB"}],"dependencies":{"follow-redirects":"1.5.10"},"deprecated":false,"description":"Promise based HTTP client for the browser and node.js","devDependencies":{"bundlesize":"^0.17.0","coveralls":"^3.0.0","es6-promise":"^4.2.4","grunt":"^1.0.2","grunt-banner":"^0.6.0","grunt-cli":"^1.2.0","grunt-contrib-clean":"^1.1.0","grunt-contrib-watch":"^1.0.0","grunt-eslint":"^20.1.0","grunt-karma":"^2.0.0","grunt-mocha-test":"^0.13.3","grunt-ts":"^6.0.0-beta.19","grunt-webpack":"^1.0.18","istanbul-instrumenter-loader":"^1.0.0","jasmine-core":"^2.4.1","karma":"^1.3.0","karma-chrome-launcher":"^2.2.0","karma-coverage":"^1.1.1","karma-firefox-launcher":"^1.1.0","karma-jasmine":"^1.1.1","karma-jasmine-ajax":"^0.1.13","karma-opera-launcher":"^1.0.0","karma-safari-launcher":"^1.0.0","karma-sauce-launcher":"^1.2.0","karma-sinon":"^1.0.5","karma-sourcemap-loader":"^0.3.7","karma-webpack":"^1.7.0","load-grunt-tasks":"^3.5.2","minimist":"^1.2.0","mocha":"^5.2.0","sinon":"^4.5.0","typescript":"^2.8.1","url-search-params":"^0.10.0","webpack":"^1.13.1","webpack-dev-server":"^1.14.1"},"homepage":"https://github.com/axios/axios","keywords":["xhr","http","ajax","promise","node"],"license":"MIT","main":"index.js","name":"axios","repository":{"type":"git","url":"git+https://github.com/axios/axios.git"},"scripts":{"build":"NODE_ENV=production grunt build","coveralls":"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js","examples":"node ./examples/server.js","fix":"eslint --fix lib/**/*.js","postversion":"git push && git push --tags","preversion":"npm test","start":"node ./sandbox/server.js","test":"grunt test && bundlesize","version":"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json"},"typings":"./index.d.ts","version":"0.19.2"};
+module.exports = {"_args":[["axios@0.19.2","/Users/sakai-manabu/repository/image_assembly_line"]],"_from":"axios@0.19.2","_id":"axios@0.19.2","_inBundle":false,"_integrity":"sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==","_location":"/axios","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"axios@0.19.2","name":"axios","escapedName":"axios","rawSpec":"0.19.2","saveSpec":null,"fetchSpec":"0.19.2"},"_requiredBy":["/@slack/bolt","/@slack/web-api"],"_resolved":"https://registry.npmjs.org/axios/-/axios-0.19.2.tgz","_spec":"0.19.2","_where":"/Users/sakai-manabu/repository/image_assembly_line","author":{"name":"Matt Zabriskie"},"browser":{"./lib/adapters/http.js":"./lib/adapters/xhr.js"},"bugs":{"url":"https://github.com/axios/axios/issues"},"bundlesize":[{"path":"./dist/axios.min.js","threshold":"5kB"}],"dependencies":{"follow-redirects":"1.5.10"},"description":"Promise based HTTP client for the browser and node.js","devDependencies":{"bundlesize":"^0.17.0","coveralls":"^3.0.0","es6-promise":"^4.2.4","grunt":"^1.0.2","grunt-banner":"^0.6.0","grunt-cli":"^1.2.0","grunt-contrib-clean":"^1.1.0","grunt-contrib-watch":"^1.0.0","grunt-eslint":"^20.1.0","grunt-karma":"^2.0.0","grunt-mocha-test":"^0.13.3","grunt-ts":"^6.0.0-beta.19","grunt-webpack":"^1.0.18","istanbul-instrumenter-loader":"^1.0.0","jasmine-core":"^2.4.1","karma":"^1.3.0","karma-chrome-launcher":"^2.2.0","karma-coverage":"^1.1.1","karma-firefox-launcher":"^1.1.0","karma-jasmine":"^1.1.1","karma-jasmine-ajax":"^0.1.13","karma-opera-launcher":"^1.0.0","karma-safari-launcher":"^1.0.0","karma-sauce-launcher":"^1.2.0","karma-sinon":"^1.0.5","karma-sourcemap-loader":"^0.3.7","karma-webpack":"^1.7.0","load-grunt-tasks":"^3.5.2","minimist":"^1.2.0","mocha":"^5.2.0","sinon":"^4.5.0","typescript":"^2.8.1","url-search-params":"^0.10.0","webpack":"^1.13.1","webpack-dev-server":"^1.14.1"},"homepage":"https://github.com/axios/axios","keywords":["xhr","http","ajax","promise","node"],"license":"MIT","main":"index.js","name":"axios","repository":{"type":"git","url":"git+https://github.com/axios/axios.git"},"scripts":{"build":"NODE_ENV=production grunt build","coveralls":"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js","examples":"node ./examples/server.js","fix":"eslint --fix lib/**/*.js","postversion":"git push && git push --tags","preversion":"npm test","start":"node ./sandbox/server.js","test":"grunt test && bundlesize","version":"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json"},"typings":"./index.d.ts","version":"0.19.2"};
 
 /***/ }),
 /* 362 */,
@@ -19451,20 +19451,25 @@ const client = new s3_1.default({
 });
 function uploadVulnerability(rowJson) {
     return __awaiter(this, void 0, void 0, function* () {
-        if (!process.env.BUCKET_NAME) {
+        if (!process.env.LOGS_BUCKET_NAME) {
             throw new Error('No bucket name.');
         }
-        const bucketName = process.env.BUCKET_NAME;
-        // Convert to JSON Lines
-        const json = JSON.stringify(JSON.parse(rowJson));
+        const bucketName = process.env.LOGS_BUCKET_NAME;
+        const json = convertToJsonLines(rowJson);
         core.debug(`JSON data: ${json}`);
         const param = {
             Bucket: bucketName,
             Key: generateObjectKey('trivy', 'json'),
-            Body: `${json}\n`,
+            Body: json,
             ContentType: 'application/json',
             ACL: 'bucket-owner-full-control'
         };
+        s3PutObject(param);
+    });
+}
+exports.uploadVulnerability = uploadVulnerability;
+function s3PutObject(param) {
+    return __awaiter(this, void 0, void 0, function* () {
         client.upload(param, (err, data) => {
             if (err) {
                 throw new Error('Failed to upload to S3.');
@@ -19473,10 +19478,9 @@ function uploadVulnerability(rowJson) {
                 core.debug(`Upload to S3: ${data.Bucket}/${data.Key}`);
             }
         });
-        return;
     });
 }
-exports.uploadVulnerability = uploadVulnerability;
+exports.s3PutObject = s3PutObject;
 function generateObjectKey(prefix, fileExtension) {
     const now = new Date(); // UTC
     const year = now.getFullYear();
@@ -19490,6 +19494,10 @@ function generateObjectKey(prefix, fileExtension) {
 }
 function zeroPadding(num, len) {
     return num.toString().padStart(len, '0');
+}
+function convertToJsonLines(json) {
+    json = JSON.stringify(JSON.parse(json));
+    return `${json}\n`;
 }
 
 
@@ -20346,6 +20354,7 @@ function dockerImageLs(imageName) {
             params: { filter: imageName },
             socketPath: '/var/run/docker.sock'
         });
+        // Make sure that images are sorted by "Created" desc.
         return res.data.sort((im1, im2) => {
             return im2.Created - im1.Created;
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import Docker from './docker'
 import {BuildError, ScanError, PushError} from './error'
 import {setDelivery} from './deliver'
 import * as notification from './notification'
+import * as s3 from './s3'
 import {BuildAction} from './types'
 
 async function run(): Promise<void> {
@@ -23,6 +24,8 @@ async function run(): Promise<void> {
     if (process.env.GITHUB_TOKEN) {
       core.setSecret(process.env.GITHUB_TOKEN)
     }
+
+    const startTime = new Date() // UTC
 
     const target = core.getInput('target')
     core.debug(`target: ${target}`)
@@ -65,6 +68,9 @@ async function run(): Promise<void> {
         gitHubRunID: process.env.GITHUB_RUN_ID
       })
     }
+
+    const endTime = new Date() // UTC
+    s3.uploadBuildTime(startTime, endTime)
   } catch (e) {
     if (e instanceof BuildError) {
       core.error('image build error')

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -17,7 +17,7 @@ export async function uploadVulnerability(rowJson: string): Promise<void> {
 
   const param: s3.Types.PutObjectRequest = {
     Bucket: bucketName,
-    Key: generateObjectKey('trivy', 'json'),
+    Key: generateObjectKey('trivy/', 'json'),
     Body: json,
     ContentType: 'application/json',
     ACL: 'bucket-owner-full-control'
@@ -43,7 +43,7 @@ export async function uploadBuildTime(
 
   const param: s3.Types.PutObjectRequest = {
     Bucket: bucketName,
-    Key: generateObjectKey('build', 'json'),
+    Key: generateObjectKey('build/dt=', 'json'),
     Body: json,
     ContentType: 'application/json'
   }
@@ -73,7 +73,7 @@ function generateObjectKey(prefix: string, fileExtension: string): string {
   const second = zeroPadding(now.getSeconds(), 2)
 
   const objectKey = `${year}-${month}-${date}/${hour}-${minute}-${second}-${uuidv4()}`
-  return `${prefix}/${objectKey}.${fileExtension}`
+  return `${prefix}${objectKey}.${fileExtension}`
 }
 
 function zeroPadding(num: number, len: number): string {

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -26,6 +26,31 @@ export async function uploadVulnerability(rowJson: string): Promise<void> {
   s3PutObject(param)
 }
 
+export async function uploadBuildTime(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  startTime: Date,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  endTime: Date
+): Promise<void> {
+  if (!process.env.METRICS_BUCKET_NAME) {
+    throw new Error('No bucket name.')
+  }
+  const bucketName: string = process.env.METRICS_BUCKET_NAME
+
+  const rowJson = '{}' // ToDo
+  const json: string = convertToJsonLines(rowJson)
+  core.debug(`JSON data: ${json}`)
+
+  const param: s3.Types.PutObjectRequest = {
+    Bucket: bucketName,
+    Key: generateObjectKey('build', 'json'),
+    Body: json,
+    ContentType: 'application/json'
+  }
+
+  s3PutObject(param)
+}
+
 export async function s3PutObject(
   param: s3.Types.PutObjectRequest
 ): Promise<void> {


### PR DESCRIPTION
image_assembly_line の実行時間に関するメトリクスを S3 にアップロードできるようにします。
レビューの範囲を絞るために、この PR ではアップロードする JSON の中身は空にしています。

## 📝 レビューポイント

- [x] テスト用のビルドで `Upload to S3` の文字が 2 回出力されている
  - https://github.com/C-FO/build-image/runs/783110422?check_suite_focus=true
- [x] `METRICS_BUCKET_NAME` に JSON ファイルがアップロードされている
  - `METRICS_BUCKET_NAME/build/%Y-%m-%d/%H-%M-%S-uuid.json`
- [x] 上記の JSON ファイルの中身が `{}\n` である