### PR TITLE
Tag 付けされた Image 全てを ECR に push するようにする

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7216,14 +7216,15 @@ function run() {
             core.debug(`docker: ${docker.toString()}`);
             yield docker.build(target);
             yield docker.scan(severityLevel, scanExitCode);
-            if (noPush.toString() === 'true') {
-                core.info('no_push: true');
-            }
-            else {
-                yield docker.push('latest');
-                yield docker.push(commitHash);
-            }
             if (docker.builtImage && process.env.GITHUB_RUN_ID) {
+                if (noPush.toString() === 'true') {
+                    core.info('no_push: true');
+                }
+                else {
+                    for (const tag of docker.builtImage.tags) {
+                        yield docker.push(tag);
+                    }
+                }
                 yield deliver_1.setDelivery({
                     dockerImage: docker.builtImage,
                     gitHubRunID: process.env.GITHUB_RUN_ID
@@ -20346,6 +20347,7 @@ function dockerImageLs(imageName) {
             params: { filter: imageName },
             socketPath: '/var/run/docker.sock'
         });
+        // Make sure that images are sorted by "Created" desc.
         return res.data.sort((im1, im2) => {
             return im2.Created - im1.Created;
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,14 +52,14 @@ async function run(): Promise<void> {
 
     await docker.scan(severityLevel, scanExitCode)
 
-    if (noPush.toString() === 'true') {
-      core.info('no_push: true')
-    } else {
-      await docker.push('latest')
-      await docker.push(commitHash)
-    }
-
     if (docker.builtImage && process.env.GITHUB_RUN_ID) {
+      if (noPush.toString() === 'true') {
+        core.info('no_push: true')
+      } else {
+        for (const tag of docker.builtImage.tags) {
+          await docker.push(tag)
+        }
+      }
       await setDelivery({
         dockerImage: docker.builtImage,
         gitHubRunID: process.env.GITHUB_RUN_ID


### PR DESCRIPTION
# 変更点
## builtImage に入っている tag を全て push するようにした
これまで以下のように tag を指定して push していましたが
```typescript
await docker.push('latest')	
await docker.push(commitHash)
```

`builtImage` 内に同一 ID の tag 配列があるのでそれを使って1つずつ push するように変更しました。
`commitHash` は指定しなくとも tag 付けしてあるので push されます

# 相談
これまでは `latest` を指定していましたが、それは make 内で指定されていたらで良いかと思ったんですがどうでしょう？
既存の実装に頼っている所があるなら `latest` を tag 付けして push しようかと

# やっていないこと
恐らく builtImage は DockerImage インターフェイスなのを class に変えて DockerImage#push() を作った方が for文などを main 内で実行せずに済むしテストしやすい実装になりそうと思いつつまずはこのままにしてしまいました

# リンク
- [JIRAチケット: release tag を docker tag 付けして push する](https://jira-freee.atlassian.net/browse/CONTAINER-222)

# 確認
- [x] build-image での実行が成功していること
  - [x] [実行した Workflow](https://github.com/C-FO/build-image/runs/797757289?check_suite_focus=true)
- [x] ECR に tag 付けされた Image が push されていること(現段階では以下)
  - [x] latest
  - [x] v.1.1
  - [x] コミットハッシュ