### PR TITLE
Add column for recovery time

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2841,7 +2841,61 @@ module.exports = function createError(message, config, code, request, response) 
 /* 31 */,
 /* 32 */,
 /* 33 */,
-/* 34 */,
+/* 34 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(__webpack_require__(470));
+const ecr_1 = __importDefault(__webpack_require__(787));
+const client = new ecr_1.default({
+    region: process.env.AWS_REGION
+});
+function getLatestImage(repositoryName) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const params = {
+            // eslint-disable-next-line object-shorthand
+            repositoryName: repositoryName,
+            imageIds: [
+                {
+                    imageTag: 'latest'
+                }
+            ]
+        };
+        const images = yield client.describeImages(params).promise();
+        if (images.imageDetails) {
+            core.debug(`repository name: ${images.imageDetails[0].repositoryName}`);
+            return images.imageDetails;
+        }
+        else {
+            throw new Error('Image not found');
+        }
+    });
+}
+exports.getLatestImage = getLatestImage;
+
+
+/***/ }),
 /* 35 */
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
@@ -3363,7 +3417,7 @@ module.exports = {"version":"2.0","metadata":{"apiVersion":"2014-06-30","endpoin
 /* 59 */
 /***/ (function(module) {
 
-module.exports = {"_args":[["@slack/web-api@5.9.0","/Users/mori-daisuke/go/src/github.com/C-FO/image_assembly_line"]],"_from":"@slack/web-api@5.9.0","_id":"@slack/web-api@5.9.0","_inBundle":false,"_integrity":"sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==","_location":"/@slack/web-api","_phantomChildren":{"asynckit":"0.4.0","combined-stream":"1.0.8","mime-types":"2.1.25"},"_requested":{"type":"version","registry":true,"raw":"@slack/web-api@5.9.0","name":"@slack/web-api","escapedName":"@slack%2fweb-api","scope":"@slack","rawSpec":"5.9.0","saveSpec":null,"fetchSpec":"5.9.0"},"_requiredBy":["/@slack/bolt","/@slack/oauth"],"_resolved":"https://registry.npmjs.org/@slack/web-api/-/web-api-5.9.0.tgz","_spec":"5.9.0","_where":"/Users/mori-daisuke/go/src/github.com/C-FO/image_assembly_line","author":{"name":"Slack Technologies, Inc."},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.2.1","@types/is-stream":"^1.1.0","@types/node":">=8.9.0","@types/p-queue":"^2.3.2","axios":"^0.19.0","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^2.4.2","p-retry":"^4.0.0"},"description":"Official library for using the Slack Platform's Web API","devDependencies":{"@aoberoi/capture-console":"^1.1.0","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^8.0.3","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^3.3.3333"},"engines":{"node":">= 8.9.0","npm":">= 5.5.1"},"files":["dist/**/*"],"homepage":"https://slack.dev/node-slack-sdk/web-api","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"license":"MIT","main":"dist/index.js","name":"@slack/web-api","publishConfig":{"access":"public"},"repository":{"type":"git","url":"git+https://github.com/slackapi/node-slack-sdk.git"},"scripts":{"build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","coverage":"codecov -F webapi --root=$PWD","lint":"tslint --project .","prepare":"npm run build","test":"npm run build && nyc mocha --config .mocharc.json src/*.spec.js"},"types":"./dist/index.d.ts","version":"5.9.0"};
+module.exports = {"_args":[["@slack/web-api@5.9.0","/Users/sakai-manabu/repository/image_assembly_line"]],"_from":"@slack/web-api@5.9.0","_id":"@slack/web-api@5.9.0","_inBundle":false,"_integrity":"sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==","_location":"/@slack/web-api","_phantomChildren":{"asynckit":"0.4.0","combined-stream":"1.0.8","mime-types":"2.1.25"},"_requested":{"type":"version","registry":true,"raw":"@slack/web-api@5.9.0","name":"@slack/web-api","escapedName":"@slack%2fweb-api","scope":"@slack","rawSpec":"5.9.0","saveSpec":null,"fetchSpec":"5.9.0"},"_requiredBy":["/@slack/bolt","/@slack/oauth"],"_resolved":"https://registry.npmjs.org/@slack/web-api/-/web-api-5.9.0.tgz","_spec":"5.9.0","_where":"/Users/sakai-manabu/repository/image_assembly_line","author":{"name":"Slack Technologies, Inc."},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.2.1","@types/is-stream":"^1.1.0","@types/node":">=8.9.0","@types/p-queue":"^2.3.2","axios":"^0.19.0","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^2.4.2","p-retry":"^4.0.0"},"description":"Official library for using the Slack Platform's Web API","devDependencies":{"@aoberoi/capture-console":"^1.1.0","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^8.0.3","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^3.3.3333"},"engines":{"node":">= 8.9.0","npm":">= 5.5.1"},"files":["dist/**/*"],"homepage":"https://slack.dev/node-slack-sdk/web-api","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"license":"MIT","main":"dist/index.js","name":"@slack/web-api","publishConfig":{"access":"public"},"repository":{"type":"git","url":"git+https://github.com/slackapi/node-slack-sdk.git"},"scripts":{"build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","coverage":"codecov -F webapi --root=$PWD","lint":"tslint --project .","prepare":"npm run build","test":"npm run build && nyc mocha --config .mocharc.json src/*.spec.js"},"types":"./dist/index.d.ts","version":"5.9.0"};
 
 /***/ }),
 /* 60 */,
@@ -7195,6 +7249,7 @@ function run() {
             commitSHA: process.env.GITHUB_SHA,
             runID: process.env.GITHUB_RUN_ID
         });
+        const startTime = new Date(); // UTC
         try {
             // REGISTRY_NAME はユーザー側から渡せない様にする
             const registry = process.env.REGISTRY_NAME;
@@ -7205,7 +7260,6 @@ function run() {
             if (process.env.GITHUB_TOKEN) {
                 core.setSecret(process.env.GITHUB_TOKEN);
             }
-            const startTime = new Date(); // UTC
             const target = core.getInput('target');
             core.debug(`target: ${target}`);
             const imageName = core.getInput('image_name');
@@ -7240,26 +7294,34 @@ function run() {
                 });
             }
             const endTime = new Date(); // UTC
-            s3.uploadBuildTime(startTime, endTime);
+            s3.uploadBuildTime(startTime, endTime, imageName, 'success', 'NoError');
             const elapsedSec = (endTime.getTime() - startTime.getTime()) / 1000;
             const buildTime = `${Math.floor(elapsedSec / 60)}min ${elapsedSec % 60}sec`;
             notification.notifyReadyToDeploy(thisAction, imageName, buildTime, (_a = docker.builtImage) === null || _a === void 0 ? void 0 : _a.tags.join(', '));
         }
         catch (e) {
+            let buildReason;
             if (e instanceof error_1.BuildError) {
+                buildReason = 'BuildError';
                 core.error('image build error');
                 notification.notifyBuildFailed(thisAction);
             }
             else if (e instanceof error_1.ScanError) {
+                buildReason = 'ScanError';
                 core.error('image scan error');
             }
             else if (e instanceof error_1.PushError) {
+                buildReason = 'PushError';
                 core.error('ecr push error');
             }
             else {
+                buildReason = 'UnknownError';
                 core.error(e.message);
                 core.error('unknown error');
             }
+            const endTime = new Date(); // UTC
+            const imageName = core.getInput('image_name');
+            s3.uploadBuildTime(startTime, endTime, imageName, 'fail', buildReason);
             core.setFailed(e);
         }
     });
@@ -9547,7 +9609,7 @@ module.exports = require("assert");
 /* 361 */
 /***/ (function(module) {
 
-module.exports = {"_args":[["axios@0.19.2","/Users/mori-daisuke/go/src/github.com/C-FO/image_assembly_line"]],"_from":"axios@0.19.2","_id":"axios@0.19.2","_inBundle":false,"_integrity":"sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==","_location":"/axios","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"axios@0.19.2","name":"axios","escapedName":"axios","rawSpec":"0.19.2","saveSpec":null,"fetchSpec":"0.19.2"},"_requiredBy":["/@slack/bolt","/@slack/web-api"],"_resolved":"https://registry.npmjs.org/axios/-/axios-0.19.2.tgz","_spec":"0.19.2","_where":"/Users/mori-daisuke/go/src/github.com/C-FO/image_assembly_line","author":{"name":"Matt Zabriskie"},"browser":{"./lib/adapters/http.js":"./lib/adapters/xhr.js"},"bugs":{"url":"https://github.com/axios/axios/issues"},"bundlesize":[{"path":"./dist/axios.min.js","threshold":"5kB"}],"dependencies":{"follow-redirects":"1.5.10"},"description":"Promise based HTTP client for the browser and node.js","devDependencies":{"bundlesize":"^0.17.0","coveralls":"^3.0.0","es6-promise":"^4.2.4","grunt":"^1.0.2","grunt-banner":"^0.6.0","grunt-cli":"^1.2.0","grunt-contrib-clean":"^1.1.0","grunt-contrib-watch":"^1.0.0","grunt-eslint":"^20.1.0","grunt-karma":"^2.0.0","grunt-mocha-test":"^0.13.3","grunt-ts":"^6.0.0-beta.19","grunt-webpack":"^1.0.18","istanbul-instrumenter-loader":"^1.0.0","jasmine-core":"^2.4.1","karma":"^1.3.0","karma-chrome-launcher":"^2.2.0","karma-coverage":"^1.1.1","karma-firefox-launcher":"^1.1.0","karma-jasmine":"^1.1.1","karma-jasmine-ajax":"^0.1.13","karma-opera-launcher":"^1.0.0","karma-safari-launcher":"^1.0.0","karma-sauce-launcher":"^1.2.0","karma-sinon":"^1.0.5","karma-sourcemap-loader":"^0.3.7","karma-webpack":"^1.7.0","load-grunt-tasks":"^3.5.2","minimist":"^1.2.0","mocha":"^5.2.0","sinon":"^4.5.0","typescript":"^2.8.1","url-search-params":"^0.10.0","webpack":"^1.13.1","webpack-dev-server":"^1.14.1"},"homepage":"https://github.com/axios/axios","keywords":["xhr","http","ajax","promise","node"],"license":"MIT","main":"index.js","name":"axios","repository":{"type":"git","url":"git+https://github.com/axios/axios.git"},"scripts":{"build":"NODE_ENV=production grunt build","coveralls":"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js","examples":"node ./examples/server.js","fix":"eslint --fix lib/**/*.js","postversion":"git push && git push --tags","preversion":"npm test","start":"node ./sandbox/server.js","test":"grunt test && bundlesize","version":"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json"},"typings":"./index.d.ts","version":"0.19.2"};
+module.exports = {"_args":[["axios@0.19.2","/Users/sakai-manabu/repository/image_assembly_line"]],"_from":"axios@0.19.2","_id":"axios@0.19.2","_inBundle":false,"_integrity":"sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==","_location":"/axios","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"axios@0.19.2","name":"axios","escapedName":"axios","rawSpec":"0.19.2","saveSpec":null,"fetchSpec":"0.19.2"},"_requiredBy":["/@slack/bolt","/@slack/web-api"],"_resolved":"https://registry.npmjs.org/axios/-/axios-0.19.2.tgz","_spec":"0.19.2","_where":"/Users/sakai-manabu/repository/image_assembly_line","author":{"name":"Matt Zabriskie"},"browser":{"./lib/adapters/http.js":"./lib/adapters/xhr.js"},"bugs":{"url":"https://github.com/axios/axios/issues"},"bundlesize":[{"path":"./dist/axios.min.js","threshold":"5kB"}],"dependencies":{"follow-redirects":"1.5.10"},"description":"Promise based HTTP client for the browser and node.js","devDependencies":{"bundlesize":"^0.17.0","coveralls":"^3.0.0","es6-promise":"^4.2.4","grunt":"^1.0.2","grunt-banner":"^0.6.0","grunt-cli":"^1.2.0","grunt-contrib-clean":"^1.1.0","grunt-contrib-watch":"^1.0.0","grunt-eslint":"^20.1.0","grunt-karma":"^2.0.0","grunt-mocha-test":"^0.13.3","grunt-ts":"^6.0.0-beta.19","grunt-webpack":"^1.0.18","istanbul-instrumenter-loader":"^1.0.0","jasmine-core":"^2.4.1","karma":"^1.3.0","karma-chrome-launcher":"^2.2.0","karma-coverage":"^1.1.1","karma-firefox-launcher":"^1.1.0","karma-jasmine":"^1.1.1","karma-jasmine-ajax":"^0.1.13","karma-opera-launcher":"^1.0.0","karma-safari-launcher":"^1.0.0","karma-sauce-launcher":"^1.2.0","karma-sinon":"^1.0.5","karma-sourcemap-loader":"^0.3.7","karma-webpack":"^1.7.0","load-grunt-tasks":"^3.5.2","minimist":"^1.2.0","mocha":"^5.2.0","sinon":"^4.5.0","typescript":"^2.8.1","url-search-params":"^0.10.0","webpack":"^1.13.1","webpack-dev-server":"^1.14.1"},"homepage":"https://github.com/axios/axios","keywords":["xhr","http","ajax","promise","node"],"license":"MIT","main":"index.js","name":"axios","repository":{"type":"git","url":"git+https://github.com/axios/axios.git"},"scripts":{"build":"NODE_ENV=production grunt build","coveralls":"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js","examples":"node ./examples/server.js","fix":"eslint --fix lib/**/*.js","postversion":"git push && git push --tags","preversion":"npm test","start":"node ./sandbox/server.js","test":"grunt test && bundlesize","version":"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json"},"typings":"./index.d.ts","version":"0.19.2"};
 
 /***/ }),
 /* 362 */,
@@ -17249,7 +17311,12 @@ AWS.FileSystemCredentials = AWS.util.inherit(AWS.Credentials, {
 
 /***/ }),
 /* 635 */,
-/* 636 */,
+/* 636 */
+/***/ (function(module) {
+
+module.exports = {"version":2,"waiters":{"ImageScanComplete":{"description":"Wait until an image scan is complete and findings can be accessed","operation":"DescribeImageScanFindings","delay":5,"maxAttempts":60,"acceptors":[{"state":"success","matcher":"path","argument":"imageScanStatus.status","expected":"COMPLETE"},{"state":"failure","matcher":"path","argument":"imageScanStatus.status","expected":"FAILED"}]},"LifecyclePolicyPreviewComplete":{"description":"Wait until a lifecycle policy preview request is complete and results can be accessed","operation":"GetLifecyclePolicyPreview","delay":5,"maxAttempts":20,"acceptors":[{"state":"success","matcher":"path","argument":"status","expected":"COMPLETE"},{"state":"failure","matcher":"path","argument":"status","expected":"FAILED"}]}}};
+
+/***/ }),
 /* 637 */,
 /* 638 */,
 /* 639 */,
@@ -19515,6 +19582,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const s3_1 = __importDefault(__webpack_require__(777));
 const uuid_1 = __webpack_require__(281);
+const ecr = __importStar(__webpack_require__(34));
 const client = new s3_1.default({
     region: process.env.AWS_REGION
 });
@@ -19537,19 +19605,27 @@ function uploadVulnerability(rowJson) {
     });
 }
 exports.uploadVulnerability = uploadVulnerability;
-function uploadBuildTime(startTime, endTime) {
+function uploadBuildTime(startTime, endTime, repositoryName, buildResult, buildReason) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!process.env.METRICS_BUCKET_NAME) {
             throw new Error('No bucket name.');
         }
         const bucketName = process.env.METRICS_BUCKET_NAME;
+        const latestImage = yield ecr.getLatestImage(repositoryName);
+        if (!latestImage[0].imagePushedAt) {
+            throw new Error('No push date.');
+        }
+        const imagePushedAt = latestImage[0].imagePushedAt;
         /* eslint-disable @typescript-eslint/camelcase */
         const buildData = {
             start_at: convertDateTimeFormat(startTime),
             end_at: convertDateTimeFormat(endTime),
             repository: process.env.GITHUB_REPOSITORY,
             branch: process.env.GITHUB_REF,
-            run_id: process.env.GITHUB_RUN_ID
+            run_id: process.env.GITHUB_RUN_ID,
+            pushed_at: convertDateTimeFormat(imagePushedAt),
+            result: buildResult,
+            reason: buildReason
         };
         /* eslint-enable */
         const json = `${JSON.stringify(buildData)}\n`;
@@ -22592,7 +22668,31 @@ module.exports = Axios;
 /* 784 */,
 /* 785 */,
 /* 786 */,
-/* 787 */,
+/* 787 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+__webpack_require__(234);
+var AWS = __webpack_require__(395);
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
+
+apiLoader.services['ecr'] = {};
+AWS.ECR = Service.defineService('ecr', ['2015-09-21']);
+Object.defineProperty(apiLoader.services['ecr'], '2015-09-21', {
+  get: function get() {
+    var model = __webpack_require__(849);
+    model.paginators = __webpack_require__(907).pagination;
+    model.waiters = __webpack_require__(636).waiters;
+    return model;
+  },
+  enumerable: true,
+  configurable: true
+});
+
+module.exports = AWS.ECR;
+
+
+/***/ }),
 /* 788 */
 /***/ (function(module, __unusedexports, __webpack_require__) {
 
@@ -25963,7 +26063,12 @@ exports.getLogger = getLogger;
 
 /***/ }),
 /* 848 */,
-/* 849 */,
+/* 849 */
+/***/ (function(module) {
+
+module.exports = {"version":"2.0","metadata":{"apiVersion":"2015-09-21","endpointPrefix":"api.ecr","jsonVersion":"1.1","protocol":"json","serviceAbbreviation":"Amazon ECR","serviceFullName":"Amazon EC2 Container Registry","serviceId":"ECR","signatureVersion":"v4","signingName":"ecr","targetPrefix":"AmazonEC2ContainerRegistry_V20150921","uid":"ecr-2015-09-21"},"operations":{"BatchCheckLayerAvailability":{"input":{"type":"structure","required":["repositoryName","layerDigests"],"members":{"registryId":{},"repositoryName":{},"layerDigests":{"type":"list","member":{}}}},"output":{"type":"structure","members":{"layers":{"type":"list","member":{"type":"structure","members":{"layerDigest":{},"layerAvailability":{},"layerSize":{"type":"long"},"mediaType":{}}}},"failures":{"type":"list","member":{"type":"structure","members":{"layerDigest":{},"failureCode":{},"failureReason":{}}}}}}},"BatchDeleteImage":{"input":{"type":"structure","required":["repositoryName","imageIds"],"members":{"registryId":{},"repositoryName":{},"imageIds":{"shape":"Si"}}},"output":{"type":"structure","members":{"imageIds":{"shape":"Si"},"failures":{"shape":"Sn"}}}},"BatchGetImage":{"input":{"type":"structure","required":["repositoryName","imageIds"],"members":{"registryId":{},"repositoryName":{},"imageIds":{"shape":"Si"},"acceptedMediaTypes":{"type":"list","member":{}}}},"output":{"type":"structure","members":{"images":{"type":"list","member":{"shape":"Sv"}},"failures":{"shape":"Sn"}}}},"CompleteLayerUpload":{"input":{"type":"structure","required":["repositoryName","uploadId","layerDigests"],"members":{"registryId":{},"repositoryName":{},"uploadId":{},"layerDigests":{"type":"list","member":{}}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"uploadId":{},"layerDigest":{}}}},"CreateRepository":{"input":{"type":"structure","required":["repositoryName"],"members":{"repositoryName":{},"tags":{"shape":"S12"},"imageTagMutability":{},"imageScanningConfiguration":{"shape":"S17"}}},"output":{"type":"structure","members":{"repository":{"shape":"S1a"}}}},"DeleteLifecyclePolicy":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"lifecyclePolicyText":{},"lastEvaluatedAt":{"type":"timestamp"}}}},"DeleteRepository":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{},"force":{"type":"boolean"}}},"output":{"type":"structure","members":{"repository":{"shape":"S1a"}}}},"DeleteRepositoryPolicy":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"policyText":{}}}},"DescribeImageScanFindings":{"input":{"type":"structure","required":["repositoryName","imageId"],"members":{"registryId":{},"repositoryName":{},"imageId":{"shape":"Sj"},"nextToken":{},"maxResults":{"type":"integer"}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"imageId":{"shape":"Sj"},"imageScanStatus":{"shape":"S1s"},"imageScanFindings":{"type":"structure","members":{"imageScanCompletedAt":{"type":"timestamp"},"vulnerabilitySourceUpdatedAt":{"type":"timestamp"},"findings":{"type":"list","member":{"type":"structure","members":{"name":{},"description":{},"uri":{},"severity":{},"attributes":{"type":"list","member":{"type":"structure","required":["key"],"members":{"key":{},"value":{}}}}}}},"findingSeverityCounts":{"shape":"S27"}}},"nextToken":{}}}},"DescribeImages":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{},"imageIds":{"shape":"Si"},"nextToken":{},"maxResults":{"type":"integer"},"filter":{"type":"structure","members":{"tagStatus":{}}}}},"output":{"type":"structure","members":{"imageDetails":{"type":"list","member":{"type":"structure","members":{"registryId":{},"repositoryName":{},"imageDigest":{},"imageTags":{"shape":"S2f"},"imageSizeInBytes":{"type":"long"},"imagePushedAt":{"type":"timestamp"},"imageScanStatus":{"shape":"S1s"},"imageScanFindingsSummary":{"type":"structure","members":{"imageScanCompletedAt":{"type":"timestamp"},"vulnerabilitySourceUpdatedAt":{"type":"timestamp"},"findingSeverityCounts":{"shape":"S27"}}}}}},"nextToken":{}}}},"DescribeRepositories":{"input":{"type":"structure","members":{"registryId":{},"repositoryNames":{"type":"list","member":{}},"nextToken":{},"maxResults":{"type":"integer"}}},"output":{"type":"structure","members":{"repositories":{"type":"list","member":{"shape":"S1a"}},"nextToken":{}}}},"GetAuthorizationToken":{"input":{"type":"structure","members":{"registryIds":{"type":"list","member":{}}}},"output":{"type":"structure","members":{"authorizationData":{"type":"list","member":{"type":"structure","members":{"authorizationToken":{},"expiresAt":{"type":"timestamp"},"proxyEndpoint":{}}}}}}},"GetDownloadUrlForLayer":{"input":{"type":"structure","required":["repositoryName","layerDigest"],"members":{"registryId":{},"repositoryName":{},"layerDigest":{}}},"output":{"type":"structure","members":{"downloadUrl":{},"layerDigest":{}}}},"GetLifecyclePolicy":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"lifecyclePolicyText":{},"lastEvaluatedAt":{"type":"timestamp"}}}},"GetLifecyclePolicyPreview":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{},"imageIds":{"shape":"Si"},"nextToken":{},"maxResults":{"type":"integer"},"filter":{"type":"structure","members":{"tagStatus":{}}}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"lifecyclePolicyText":{},"status":{},"nextToken":{},"previewResults":{"type":"list","member":{"type":"structure","members":{"imageTags":{"shape":"S2f"},"imageDigest":{},"imagePushedAt":{"type":"timestamp"},"action":{"type":"structure","members":{"type":{}}},"appliedRulePriority":{"type":"integer"}}}},"summary":{"type":"structure","members":{"expiringImageTotalCount":{"type":"integer"}}}}}},"GetRepositoryPolicy":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"policyText":{}}}},"InitiateLayerUpload":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{}}},"output":{"type":"structure","members":{"uploadId":{},"partSize":{"type":"long"}}}},"ListImages":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{},"nextToken":{},"maxResults":{"type":"integer"},"filter":{"type":"structure","members":{"tagStatus":{}}}}},"output":{"type":"structure","members":{"imageIds":{"shape":"Si"},"nextToken":{}}}},"ListTagsForResource":{"input":{"type":"structure","required":["resourceArn"],"members":{"resourceArn":{}}},"output":{"type":"structure","members":{"tags":{"shape":"S12"}}}},"PutImage":{"input":{"type":"structure","required":["repositoryName","imageManifest"],"members":{"registryId":{},"repositoryName":{},"imageManifest":{},"imageManifestMediaType":{},"imageTag":{}}},"output":{"type":"structure","members":{"image":{"shape":"Sv"}}}},"PutImageScanningConfiguration":{"input":{"type":"structure","required":["repositoryName","imageScanningConfiguration"],"members":{"registryId":{},"repositoryName":{},"imageScanningConfiguration":{"shape":"S17"}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"imageScanningConfiguration":{"shape":"S17"}}}},"PutImageTagMutability":{"input":{"type":"structure","required":["repositoryName","imageTagMutability"],"members":{"registryId":{},"repositoryName":{},"imageTagMutability":{}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"imageTagMutability":{}}}},"PutLifecyclePolicy":{"input":{"type":"structure","required":["repositoryName","lifecyclePolicyText"],"members":{"registryId":{},"repositoryName":{},"lifecyclePolicyText":{}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"lifecyclePolicyText":{}}}},"SetRepositoryPolicy":{"input":{"type":"structure","required":["repositoryName","policyText"],"members":{"registryId":{},"repositoryName":{},"policyText":{},"force":{"type":"boolean"}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"policyText":{}}}},"StartImageScan":{"input":{"type":"structure","required":["repositoryName","imageId"],"members":{"registryId":{},"repositoryName":{},"imageId":{"shape":"Sj"}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"imageId":{"shape":"Sj"},"imageScanStatus":{"shape":"S1s"}}}},"StartLifecyclePolicyPreview":{"input":{"type":"structure","required":["repositoryName"],"members":{"registryId":{},"repositoryName":{},"lifecyclePolicyText":{}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"lifecyclePolicyText":{},"status":{}}}},"TagResource":{"input":{"type":"structure","required":["resourceArn","tags"],"members":{"resourceArn":{},"tags":{"shape":"S12"}}},"output":{"type":"structure","members":{}}},"UntagResource":{"input":{"type":"structure","required":["resourceArn","tagKeys"],"members":{"resourceArn":{},"tagKeys":{"type":"list","member":{}}}},"output":{"type":"structure","members":{}}},"UploadLayerPart":{"input":{"type":"structure","required":["repositoryName","uploadId","partFirstByte","partLastByte","layerPartBlob"],"members":{"registryId":{},"repositoryName":{},"uploadId":{},"partFirstByte":{"type":"long"},"partLastByte":{"type":"long"},"layerPartBlob":{"type":"blob"}}},"output":{"type":"structure","members":{"registryId":{},"repositoryName":{},"uploadId":{},"lastByteReceived":{"type":"long"}}}}},"shapes":{"Si":{"type":"list","member":{"shape":"Sj"}},"Sj":{"type":"structure","members":{"imageDigest":{},"imageTag":{}}},"Sn":{"type":"list","member":{"type":"structure","members":{"imageId":{"shape":"Sj"},"failureCode":{},"failureReason":{}}}},"Sv":{"type":"structure","members":{"registryId":{},"repositoryName":{},"imageId":{"shape":"Sj"},"imageManifest":{},"imageManifestMediaType":{}}},"S12":{"type":"list","member":{"type":"structure","members":{"Key":{},"Value":{}}}},"S17":{"type":"structure","members":{"scanOnPush":{"type":"boolean"}}},"S1a":{"type":"structure","members":{"repositoryArn":{},"registryId":{},"repositoryName":{},"repositoryUri":{},"createdAt":{"type":"timestamp"},"imageTagMutability":{},"imageScanningConfiguration":{"shape":"S17"}}},"S1s":{"type":"structure","members":{"status":{},"description":{}}},"S27":{"type":"map","key":{},"value":{"type":"integer"}},"S2f":{"type":"list","member":{}}}};
+
+/***/ }),
 /* 850 */,
 /* 851 */,
 /* 852 */
@@ -28952,7 +29057,12 @@ AWS.util.addPromises(AWS.CredentialProviderChain);
 
 
 /***/ }),
-/* 907 */,
+/* 907 */
+/***/ (function(module) {
+
+module.exports = {"pagination":{"DescribeImageScanFindings":{"input_token":"nextToken","limit_key":"maxResults","non_aggregate_keys":["registryId","repositoryName","imageId","imageScanStatus","imageScanFindings"],"output_token":"nextToken","result_key":"imageScanFindings.findings"},"DescribeImages":{"input_token":"nextToken","limit_key":"maxResults","output_token":"nextToken","result_key":"imageDetails"},"DescribeRepositories":{"input_token":"nextToken","limit_key":"maxResults","output_token":"nextToken","result_key":"repositories"},"GetLifecyclePolicyPreview":{"input_token":"nextToken","limit_key":"maxResults","non_aggregate_keys":["registryId","repositoryName","lifecyclePolicyText","status","summary"],"output_token":"nextToken","result_key":"previewResults"},"ListImages":{"input_token":"nextToken","limit_key":"maxResults","output_token":"nextToken","result_key":"imageIds"}}};
+
+/***/ }),
 /* 908 */,
 /* 909 */,
 /* 910 */,

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,8 @@ async function run(): Promise<void> {
     runID: process.env.GITHUB_RUN_ID
   })
 
+  const startTime = new Date() // UTC
+
   try {
     // REGISTRY_NAME はユーザー側から渡せない様にする
     const registry: string | undefined = process.env.REGISTRY_NAME
@@ -24,8 +26,6 @@ async function run(): Promise<void> {
     if (process.env.GITHUB_TOKEN) {
       core.setSecret(process.env.GITHUB_TOKEN)
     }
-
-    const startTime = new Date() // UTC
 
     const target = core.getInput('target')
     core.debug(`target: ${target}`)
@@ -70,7 +70,7 @@ async function run(): Promise<void> {
     }
 
     const endTime = new Date() // UTC
-    s3.uploadBuildTime(startTime, endTime)
+    s3.uploadBuildTime(startTime, endTime, imageName, 'success', 'NoError')
 
     const elapsedSec = (endTime.getTime() - startTime.getTime()) / 1000
     const buildTime = `${Math.floor(elapsedSec / 60)}min ${elapsedSec % 60}sec`
@@ -81,17 +81,27 @@ async function run(): Promise<void> {
       docker.builtImage?.tags.join(', ')
     )
   } catch (e) {
+    let buildReason: string
     if (e instanceof BuildError) {
+      buildReason = 'BuildError'
       core.error('image build error')
       notification.notifyBuildFailed(thisAction)
     } else if (e instanceof ScanError) {
+      buildReason = 'ScanError'
       core.error('image scan error')
     } else if (e instanceof PushError) {
+      buildReason = 'PushError'
       core.error('ecr push error')
     } else {
+      buildReason = 'UnknownError'
       core.error(e.message)
       core.error('unknown error')
     }
+
+    const endTime = new Date() // UTC
+    const imageName = core.getInput('image_name')
+    s3.uploadBuildTime(startTime, endTime, imageName, 'fail', buildReason)
+
     core.setFailed(e)
   }
 }


### PR DESCRIPTION
ビルドの復旧時間を計測するために、不足している `pushed_at`, `result`, `reason` のカラムを追加します。

## 📝 レビューポイント

* 正常系:
  * [x] ビルドが成功したときに、意図した形の JSON が出力されている
    * https://github.com/C-FO/build-image/runs/821416805?check_suite_focus=true
  * [x] ビルドが成功したときに、latest タグの作成日時と JSON の `pushed_at` が一致している
* 異常系:
  * [x] ビルドが失敗したときに、意図した形の JSON が出力されている
    * https://github.com/C-FO/build-image/runs/821506679?check_suite_focus=true
  * [x] ビルドが失敗したときに、**前回ビルド成功時**の latest タグの作成日時と JSON の `pushed_at` が一致している
* 分析:
  * [x] Athena から次のクエリを流して Design doc の仕様に沿っていることを確認する
    * `select * from buildtime where branch = 'refs/heads/add-column-for-recovery-time' order by start_at;`
  * [x] 復旧時間を求める SQL を実行して `refs/heads/add-column-for-recovery-time` の復旧時間が 3,369 秒であることを確認する