### PR TITLE
Replace the system commands with a docker engine api `image push`

### DIFF
--- a/__tests__/base64.test.ts
+++ b/__tests__/base64.test.ts
@@ -1,0 +1,17 @@
+import {base64} from '../src/base64'
+
+const ORIG_TEXT = 'test'
+const ENCODED_TEXT = 'dGVzdA=='
+
+describe('encode()', () => {
+  test('returns correctly value', () => {
+    const encoded = base64.encode(ORIG_TEXT)
+    expect(encoded).toEqual(ENCODED_TEXT)
+  })
+})
+describe('decode()', () => {
+  test('returns correctly value', () => {
+    const decoded = base64.decode(ENCODED_TEXT)
+    expect(decoded).toEqual(ORIG_TEXT)
+  })
+})

--- a/__tests__/docker-util.test.ts
+++ b/__tests__/docker-util.test.ts
@@ -2,11 +2,11 @@ import * as dockerUtil from '../src/docker-util'
 import {axiosInstance} from '../src/docker-util'
 import qs from 'qs'
 
-describe('latestBuiltImage()', () => {
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
+afterEach(() => {
+  jest.restoreAllMocks()
+})
 
+describe('latestBuiltImage()', () => {
   test('returns latest built image', async () => {
     jest.spyOn(axiosInstance, 'get').mockResolvedValueOnce(DOCKER_RESPONSE)
 
@@ -28,10 +28,6 @@ describe('latestBuiltImage()', () => {
 })
 
 describe('imageList()', () => {
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
   test('when there is some specified images', async () => {
     const mock = jest
       .spyOn(axiosInstance, 'get')
@@ -63,10 +59,6 @@ describe('imageList()', () => {
 })
 
 describe('dockerImageTag()', () => {
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
   test('when returns successfully status code', async () => {
     const dockerResponse = {
       status: 201,
@@ -92,6 +84,37 @@ describe('dockerImageTag()', () => {
     jest.spyOn(axiosInstance, 'post').mockResolvedValueOnce(dockerResponse)
     const imageTag = dockerUtil.dockerImageTag('testId', 'yyy', 'xxx')
     await expect(imageTag).rejects.toThrow()
+  })
+})
+
+describe('pushDockerImage()', () => {
+  const textEncoded = Buffer.from('test').toString('base64')
+  test('when returns successfully status code', async () => {
+    const dockerResponse = {
+      status: 200,
+      data: {}
+    }
+    const mock = jest
+      .spyOn(axiosInstance, 'post')
+      .mockResolvedValueOnce(dockerResponse)
+    await dockerUtil.pushDockerImage('testId', 'yyy', textEncoded)
+    expect(mock).toHaveBeenCalledWith(
+      'images/testId/push',
+      qs.stringify({tag: 'yyy'}),
+      {headers: {'X-Registry-Auth': textEncoded}}
+    )
+  })
+
+  test('when returns error code', async () => {
+    const dockerResponse = {
+      status: 404,
+      data: {
+        message: 'no such image'
+      }
+    }
+    jest.spyOn(axiosInstance, 'post').mockResolvedValueOnce(dockerResponse)
+    const pushImage = dockerUtil.pushDockerImage('testId', 'yyy', textEncoded)
+    await expect(pushImage).rejects.toThrow()
   })
 })
 

--- a/__tests__/docker-util.test.ts
+++ b/__tests__/docker-util.test.ts
@@ -1,6 +1,7 @@
 import * as dockerUtil from '../src/docker-util'
 import {axiosInstance} from '../src/docker-util'
 import qs from 'qs'
+import {base64} from '../src/base64'
 
 afterEach(() => {
   jest.restoreAllMocks()
@@ -88,7 +89,7 @@ describe('dockerImageTag()', () => {
 })
 
 describe('pushDockerImage()', () => {
-  const textEncoded = Buffer.from('test').toString('base64')
+  const textEncoded = base64.encode('test')
   test('when returns successfully status code', async () => {
     const dockerResponse = {
       status: 200,

--- a/dist/index.js
+++ b/dist/index.js
@@ -7957,6 +7957,7 @@ class Docker {
             let ecrLoginPass = '';
             let ecrLoginError = '';
             const options = {
+                // set silent, not to log the password
                 silent: true,
                 listeners: {
                     stdout: (data) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7406,7 +7406,25 @@ module.exports = {
 /* 203 */,
 /* 204 */,
 /* 205 */,
-/* 206 */,
+/* 206 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+const buffer_1 = __webpack_require__(293);
+exports.base64 = {
+    encode: (str) => {
+        return buffer_1.Buffer.from(str).toString('base64');
+    },
+    // for debug function
+    decode: (str) => {
+        return buffer_1.Buffer.from(str, 'base64').toString();
+    }
+};
+
+
+/***/ }),
 /* 207 */,
 /* 208 */,
 /* 209 */
@@ -7855,7 +7873,7 @@ const exec = __importStar(__webpack_require__(986));
 const docker_util_1 = __webpack_require__(708);
 const error_1 = __webpack_require__(25);
 const notification_1 = __webpack_require__(62);
-const buffer_1 = __webpack_require__(293);
+const base64_1 = __webpack_require__(206);
 class Docker {
     constructor(registry, imageName, commitHash) {
         if (!registry) {
@@ -7957,7 +7975,7 @@ class Docker {
                     email: 'none',
                     serveraddress: this.registry
                 });
-                return base64.encode(auth);
+                return base64_1.base64.encode(auth);
             }
             catch (e) {
                 core.error(ecrLoginError.trim());
@@ -8003,15 +8021,6 @@ exports.default = Docker;
 function sanitizedDomain(str) {
     return str.endsWith('/') ? str.substr(0, str.length - 1) : str;
 }
-const base64 = {
-    encode: (str) => {
-        return buffer_1.Buffer.from(str).toString('base64');
-    },
-    // for debug function
-    decode: (str) => {
-        return buffer_1.Buffer.from(str, 'base64').toString();
-    }
-};
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -20872,7 +20872,7 @@ function pushDockerImage(imageId, newTag, registryAuth) {
     return __awaiter(this, void 0, void 0, function* () {
         const res = yield exports.axiosInstance.post(`images/${imageId}/push`, qs_1.default.stringify({ tag: newTag }), { headers: { 'X-Registry-Auth': registryAuth } });
         core.info(res.data);
-        if (res.status !== 201 && res.status !== 200) {
+        if (res.status !== 200) {
             throw new Error(`POST images/{name}/push returns error, status code: ${res.status}`);
         }
     });

--- a/src/base64.ts
+++ b/src/base64.ts
@@ -1,0 +1,11 @@
+import {Buffer} from 'buffer'
+
+export const base64 = {
+  encode: (str: string) => {
+    return Buffer.from(str).toString('base64')
+  },
+  // for debug function
+  decode: (str: string) => {
+    return Buffer.from(str, 'base64').toString()
+  }
+}

--- a/src/docker-util.ts
+++ b/src/docker-util.ts
@@ -91,18 +91,20 @@ export async function dockerImageLs(
   })
 }
 
-export async function dockerPushImage(
+export async function pushDockerImage(
   imageId: string,
   newTag: string,
   registryAuth: string
 ): Promise<void> {
-  axiosInstance.defaults.headers['X-Registry-Auth'] = registryAuth
-  const res = await axiosInstance.post(`images/${imageId}/push`, {
-    params: {tag: newTag}
-  })
+  const res = await axiosInstance.post(
+    `images/${imageId}/push`,
+    qs.stringify({tag: newTag}),
+    {headers: {'X-Registry-Auth': registryAuth}}
+  )
+  core.info(res.data)
   if (res.status !== 201 && res.status !== 200) {
     throw new Error(
-      `POST images/{name}/tag returns error, status code: ${res.status}`
+      `POST images/{name}/push returns error, status code: ${res.status}`
     )
   }
 }

--- a/src/docker-util.ts
+++ b/src/docker-util.ts
@@ -102,7 +102,7 @@ export async function pushDockerImage(
     {headers: {'X-Registry-Auth': registryAuth}}
   )
   core.info(res.data)
-  if (res.status !== 201 && res.status !== 200) {
+  if (res.status !== 200) {
     throw new Error(
       `POST images/{name}/push returns error, status code: ${res.status}`
     )

--- a/src/docker-util.ts
+++ b/src/docker-util.ts
@@ -91,6 +91,22 @@ export async function dockerImageLs(
   })
 }
 
+export async function dockerPushImage(
+  imageId: string,
+  newTag: string,
+  registryAuth: string
+): Promise<void> {
+  axiosInstance.defaults.headers['X-Registry-Auth'] = registryAuth
+  const res = await axiosInstance.post(`images/${imageId}/push`, {
+    params: {tag: newTag}
+  })
+  if (res.status !== 201 && res.status !== 200) {
+    throw new Error(
+      `POST images/{name}/tag returns error, status code: ${res.status}`
+    )
+  }
+}
+
 interface DockerEngineImageResponse {
   Id: string
   RepoTags: string[]

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -11,6 +11,7 @@ import {BuildError, ScanError, PushError} from './error'
 import {Vulnerability} from './types'
 import {notifyVulnerability} from './notification'
 import {Buffer} from 'buffer'
+import {base64} from './base64'
 
 export default class Docker {
   private registry: string
@@ -168,16 +169,6 @@ export default class Docker {
 
 function sanitizedDomain(str: string): string {
   return str.endsWith('/') ? str.substr(0, str.length - 1) : str
-}
-
-const base64 = {
-  encode: (str: string) => {
-    return Buffer.from(str).toString('base64')
-  },
-  // for debug function
-  decode: (str: string) => {
-    return Buffer.from(str, 'base64').toString()
-  }
 }
 
 export interface DockerImage {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -109,6 +109,7 @@ export default class Docker {
     let ecrLoginPass = ''
     let ecrLoginError = ''
     const options: im.ExecOptions = {
+      // set silent, not to log the password
       silent: true,
       listeners: {
         stdout: (data: Buffer) => {


### PR DESCRIPTION
## Overview
- `docker image push` を `exec.exec` から docker engine apiを叩く方式へ切り替えます
- 認証情報をbase64エンコードしてヘッダに詰める必要があるのでbase64 encoderを実装しています

## Discussion
- core.infoで表示しているpush docker image処理のprogressみやすくした方が良いかどうか

## References
- [API doc](https://docs.docker.com/engine/api/v1.39/#operation/ImagePush)
- https://docs.docker.com/engine/api/v1.39/#section/Authentication

> X-Registry-Auth: string Required
A base64-encoded auth configuration. See the authentication section for details.

## Verification Information
- [Test Job Reference URL](https://github.com/C-FO/build-image/runs/893041318)