### PR TITLE
:heart: Fix NODE_ENV on integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: self-hosted
     env:
       REGISTRY_NAME: '1234567890.dkr.ecr.ap-northeast-1.amazonaws.com'
+      NODE_ENV: 'test'
     steps:
     - uses: actions/checkout@v1
     - uses: ./

--- a/dist/index.js
+++ b/dist/index.js
@@ -7589,6 +7589,8 @@ function run() {
         }
         js_1.default.start({
             apiKey: bugsnagApiKey,
+            enabledReleaseStages: ['production'],
+            appType: 'image_assembly_line',
             metadata: {
                 actionInformation: {
                     repository: gitHubRepo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,8 @@ async function run(): Promise<void> {
   }
   Bugsnag.start({
     apiKey: bugsnagApiKey,
+    enabledReleaseStages: ['production'],
+    appType: 'image_assembly_line',
     metadata: {
       actionInformation: {
         repository: gitHubRepo,


### PR DESCRIPTION
## Overview
> RepositoryNotFoundExceptiondist/index.js:33257
The repository with name 'image_assembly_line/test' does not exist in the registry with id 'xxx'

上記のようなエクセプションがBugsnagへ通知されていたので対応を行います。
リリースステージの設定でProductionのみを対象としているので、テスト実行時には `NODE_ENV=test` を明示します。
加えて通知を有効にするリリースステージを Productionへと限定します。
（ついでに appTypeへと `image_assembly_line` を入れておきます）


また `package.json` の test実行時スクリプトには変更は特に行っていません。

> Jestは自動的に NODE_ENVをtestに設定することに注意して下さい。

ref: https://doc.ebichu.cc/jest/docs/ja/getting-started.html

- [exception link](https://app.bugsnag.com/freee-kk/containerkojo/errors/5f1ff2b15bbfbd00188b8f23?filters[event.since][0]=30d&filters[error.status][0]=new)