### PR TITLE
Set releaseStage via CONTAINERKOJO_ENV

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: self-hosted
     env:
       REGISTRY_NAME: '1234567890.dkr.ecr.ap-northeast-1.amazonaws.com'
-      NODE_ENV: 'test'
+      CONTAINERKOJO_ENV: 'test'
     steps:
     - uses: actions/checkout@v1
     - uses: ./

--- a/dist/index.js
+++ b/dist/index.js
@@ -7577,6 +7577,7 @@ function run() {
         const gitHubWorkflow = env.GITHUB_WORKFLOW;
         const commitHash = env.GITHUB_SHA;
         const gitHubRunID = env.GITHUB_RUN_ID;
+        const containerkojoEnv = env.CONTAINERKOJO_ENV;
         const thisAction = new types_1.BuildAction({
             repository: gitHubRepo,
             workflow: gitHubWorkflow,
@@ -7591,6 +7592,7 @@ function run() {
             apiKey: bugsnagApiKey,
             enabledReleaseStages: ['production'],
             appType: 'image_assembly_line',
+            releaseStage: containerkojoEnv,
             metadata: {
                 actionInformation: {
                     repository: gitHubRepo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function run(): Promise<void> {
   const gitHubWorkflow = env.GITHUB_WORKFLOW
   const commitHash = env.GITHUB_SHA
   const gitHubRunID = env.GITHUB_RUN_ID
+  const containerkojoEnv = env.CONTAINERKOJO_ENV
 
   const thisAction = new BuildAction({
     repository: gitHubRepo,
@@ -29,6 +30,7 @@ async function run(): Promise<void> {
     apiKey: bugsnagApiKey,
     enabledReleaseStages: ['production'],
     appType: 'image_assembly_line',
+    releaseStage: containerkojoEnv,
     metadata: {
       actionInformation: {
         repository: gitHubRepo,


### PR DESCRIPTION
## Overview
エラーリポート通知のreleaseStageを、 `CONTAINERKOJO_ENV` から参照する形へ切り替える。
- [Bugsnag#releaseStage](https://docs.bugsnag.com/platforms/javascript/configuration-options/#releasestage)

## 動作確認

### 利用したテストスクリプト

```ts
import Bugsnag from '@bugsnag/js'

function main() {
  const env = process.env
  const apiKey = env.BUGSNAG_API_KEY
  const releaseStage = env.CONTAINERKOJO_ENV
  if (!apiKey) {
    throw new Error('Not found BUGSNAG_API_KEY.')
  }
  Bugsnag.start({
    apiKey,
    releaseStage,
    enabledReleaseStages: ['production'],
  })

  const e = new Error('releaseStage test')
  Bugsnag.notify(e)
}

main()
```

### CONTAINERKOJO_ENV = production
- 正しく通知され、チケットが作成されることを確認

```bash
❯ ts-node ./test.ts
[bugsnag] Loaded!
```

### CONTAINERKOJO_ENV = test

```bash
❯ ts-node ./test.ts
[bugsnag] Loaded!
[bugsnag] Event not sent due to releaseStage/enabledReleaseStages configuration
```