### PR TITLE
Set dependabot configuration for security patch automation

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    allowed_updates:
+      - match:
+          update_type: "security"
+    default_labels:
+      - "dependabot"
+      - "security"


### PR DESCRIPTION
## Overview
- 利用するライブラリ群のセキュリティパッチを自動更新する目的でdependabotを導入する
- 上記dependabotの設定を追加します
  - このPRが適用されたらdependabotをenableにします。

ref: https://dependabot.com/docs/config-file/