### PR TITLE
Refactoring

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7588,32 +7588,32 @@ function run() {
             runID: gitHubRunID
         });
         const bugsnagApiKey = env.BUGSNAG_API_KEY;
-        if (!bugsnagApiKey) {
-            throw new Error('BUGSNAG_API_KEY not found.');
-        }
-        js_1.default.start({
-            apiKey: bugsnagApiKey,
-            enabledReleaseStages: ['production'],
-            appType: 'image_assembly_line',
-            releaseStage: env.CONTAINERKOJO_ENV,
-            metadata: {
-                actionInformation: {
-                    repository: gitHubRepo,
-                    workflow: gitHubWorkflow,
-                    commitSHA: commitHash,
-                    runID: gitHubRunID
-                }
-            }
-        });
         // REGISTRY_NAME はユーザー側から渡せない様にする
         const registry = env.REGISTRY_NAME;
-        if (!registry) {
-            throw new Error('REGISTRY_NAME is not set.');
-        }
-        if (!commitHash) {
-            throw new Error('GITHUB_SHA not found.');
-        }
         try {
+            if (!registry) {
+                throw new Error('REGISTRY_NAME is not set.');
+            }
+            if (!commitHash) {
+                throw new Error('GITHUB_SHA not found.');
+            }
+            if (!bugsnagApiKey) {
+                throw new Error('BUGSNAG_API_KEY not found.');
+            }
+            js_1.default.start({
+                apiKey: bugsnagApiKey,
+                enabledReleaseStages: ['production'],
+                appType: 'image_assembly_line',
+                releaseStage: env.CONTAINERKOJO_ENV,
+                metadata: {
+                    actionInformation: {
+                        repository: gitHubRepo,
+                        workflow: gitHubWorkflow,
+                        commitSHA: commitHash,
+                        runID: gitHubRunID
+                    }
+                }
+            });
             if (env.GITHUB_TOKEN) {
                 core.setSecret(env.GITHUB_TOKEN);
             }
@@ -7623,8 +7623,15 @@ function run() {
             const scanExitCode = core.getInput('scan_exit_code');
             const noPush = core.getInput('no_push');
             const docker = new docker_1.default(registry, imageName, commitHash);
-            core.info(`registry: ${registry}, target: ${target}, image_name ${imageName}, commit_hash: ${commitHash}, severity_level: ${severityLevel.toString()}, scan_exit_code: ${scanExitCode.toString()}, no_push: ${noPush.toString()}`);
-            core.info(`docker: ${docker.toString()}`);
+            core.debug(`[INFORMATION]
+      registry: ${registry}
+      target: ${target}
+      image_name: ${imageName}
+      commit_hash: ${commitHash}
+      severity_level: ${severityLevel.toString()}
+      scan_exit_code: ${scanExitCode.toString()}
+      no_push: ${noPush.toString()}
+      docker: ${docker.toString()}`);
             yield docker.build(target);
             yield docker.scan(severityLevel, scanExitCode);
             if (docker.builtImage && gitHubRunID) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -8383,6 +8383,7 @@ class Docker {
             return this._builtImage;
         });
     }
+    // function for test
     testUpdate() {
         return __awaiter(this, void 0, void 0, function* () {
             if (process.env.NODE_ENV === 'test') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7623,7 +7623,7 @@ function run() {
             const scanExitCode = core.getInput('scan_exit_code');
             const noPush = core.getInput('no_push');
             const docker = new docker_1.default(registry, imageName, commitHash);
-            js_1.default.addMetadata('actionInformation', {
+            js_1.default.addMetadata('buildDetails', {
                 builtImage: docker.builtImage,
                 noPush
             });
@@ -7645,6 +7645,10 @@ function run() {
                 else {
                     const upstreamRepo = docker.upstreamRepository();
                     for (const tag of docker.builtImage.tags) {
+                        js_1.default.addMetadata('buildDetails', {
+                            tag,
+                            upstreamRegistry: upstreamRepo
+                        });
                         yield docker.tag(tag, upstreamRepo);
                         yield docker.push(tag, upstreamRepo);
                     }
@@ -7684,7 +7688,7 @@ function run() {
                 core.error(e.message);
                 core.error('unknown error');
             }
-            js_1.default.addMetadata('ErrorDetail', { reason: errorReason });
+            js_1.default.addMetadata('errorDetails', { reason: errorReason });
             js_1.default.notify(e);
             const endTime = new Date(); // UTC
             const imageName = core.getInput('image_name');

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -14,9 +14,9 @@ import {Buffer} from 'buffer'
 import {base64} from './base64'
 
 export default class Docker {
-  private registry: string
-  private imageName: string
-  private commitHash: string
+  private readonly registry: string
+  private readonly imageName: string
+  private readonly commitHash: string
   private _builtImage?: DockerImage
 
   constructor(registry: string, imageName: string, commitHash: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,7 +60,7 @@ async function run(): Promise<void> {
     const noPush = core.getInput('no_push')
 
     const docker = new Docker(registry, imageName, commitHash)
-    Bugsnag.addMetadata('actionInformation', {
+    Bugsnag.addMetadata('buildDetails', {
       builtImage: docker.builtImage,
       noPush
     })
@@ -84,6 +84,10 @@ async function run(): Promise<void> {
       } else {
         const upstreamRepo = docker.upstreamRepository()
         for (const tag of docker.builtImage.tags) {
+          Bugsnag.addMetadata('buildDetails', {
+            tag,
+            upstreamRegistry: upstreamRepo
+          })
           await docker.tag(tag, upstreamRepo)
           await docker.push(tag, upstreamRepo)
         }
@@ -126,7 +130,7 @@ async function run(): Promise<void> {
       core.error('unknown error')
     }
 
-    Bugsnag.addMetadata('ErrorDetail', {reason: errorReason})
+    Bugsnag.addMetadata('errorDetails', {reason: errorReason})
     Bugsnag.notify(e)
     const endTime = new Date() // UTC
     const imageName = core.getInput('image_name')


### PR DESCRIPTION
- main.tsの処理順を整理します
- Bugsnag通知時にほしい情報をMetadataとして追加します
  - docker.builtImage
  - errorReason
  - upstreamRepo
  - tag

#65 の続きです。
エラークラスにカスタムプロパティを持たせる案は試しましたが、Bugsnagへの通知に反映されないので、metadataを拡張する方向で進めます。

Metadataの仕様として、Rubyの Hash#mergeに近いです。key名が同じものを既に存在するSectionに入れようとすると上書きされます。
 