### PR TITLE
DescribeImages API に registryId パラメータを付ける

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2941,10 +2941,14 @@ const ecr_1 = __importDefault(__webpack_require__(787));
 const client = new ecr_1.default({
     region: process.env.AWS_REGION
 });
-function getLatestImage(repositoryName) {
+function getLatestImage(repositoryName, registryId) {
     return __awaiter(this, void 0, void 0, function* () {
+        core.debug(`[INFORMATION]
+    repositoryName: ${repositoryName}
+    registryId: ${registryId}`);
         const params = {
             repositoryName: repositoryName,
+            registryId: registryId,
             imageIds: [
                 {
                     imageTag: 'latest'
@@ -3533,7 +3537,7 @@ module.exports = {"version":"2.0","metadata":{"apiVersion":"2014-06-30","endpoin
 /* 59 */
 /***/ (function(module) {
 
-module.exports = {"_from":"@slack/web-api@^5.8.0","_id":"@slack/web-api@5.9.0","_inBundle":false,"_integrity":"sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==","_location":"/@slack/web-api","_phantomChildren":{"asynckit":"0.4.0","combined-stream":"1.0.8","mime-types":"2.1.25"},"_requested":{"type":"range","registry":true,"raw":"@slack/web-api@^5.8.0","name":"@slack/web-api","escapedName":"@slack%2fweb-api","scope":"@slack","rawSpec":"^5.8.0","saveSpec":null,"fetchSpec":"^5.8.0"},"_requiredBy":["/@slack/bolt"],"_resolved":"https://registry.npmjs.org/@slack/web-api/-/web-api-5.9.0.tgz","_shasum":"13ce1eecc405c3972e6037d54338344d7859a3b5","_spec":"@slack/web-api@^5.8.0","_where":"/Users/kaku-junichi/Workspace/image_assembly_line/node_modules/@slack/bolt","author":{"name":"Slack Technologies, Inc."},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"bundleDependencies":false,"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.2.1","@types/is-stream":"^1.1.0","@types/node":">=8.9.0","@types/p-queue":"^2.3.2","axios":"^0.19.0","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^2.4.2","p-retry":"^4.0.0"},"deprecated":false,"description":"Official library for using the Slack Platform's Web API","devDependencies":{"@aoberoi/capture-console":"^1.1.0","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^8.0.3","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^3.3.3333"},"engines":{"node":">= 8.9.0","npm":">= 5.5.1"},"files":["dist/**/*"],"homepage":"https://slack.dev/node-slack-sdk/web-api","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"license":"MIT","main":"dist/index.js","name":"@slack/web-api","publishConfig":{"access":"public"},"repository":{"type":"git","url":"git+https://github.com/slackapi/node-slack-sdk.git"},"scripts":{"build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","coverage":"codecov -F webapi --root=$PWD","lint":"tslint --project .","prepare":"npm run build","test":"npm run build && nyc mocha --config .mocharc.json src/*.spec.js"},"types":"./dist/index.d.ts","version":"5.9.0"};
+module.exports = {"_args":[["@slack/web-api@5.9.0","/app"]],"_from":"@slack/web-api@5.9.0","_id":"@slack/web-api@5.9.0","_inBundle":false,"_integrity":"sha512-gIRvuA9wGtp4S/Zc+zfT59IaGHYzNxjob2QxoJlc3JZ3BLuPMa6Lw81YBV0xutJvUVFPX2ytW27KAUakvi5ZMA==","_location":"/@slack/web-api","_phantomChildren":{"asynckit":"0.4.0","combined-stream":"1.0.8","mime-types":"2.1.25"},"_requested":{"type":"version","registry":true,"raw":"@slack/web-api@5.9.0","name":"@slack/web-api","escapedName":"@slack%2fweb-api","scope":"@slack","rawSpec":"5.9.0","saveSpec":null,"fetchSpec":"5.9.0"},"_requiredBy":["/@slack/bolt","/@slack/oauth"],"_resolved":"https://registry.npmjs.org/@slack/web-api/-/web-api-5.9.0.tgz","_spec":"5.9.0","_where":"/app","author":{"name":"Slack Technologies, Inc."},"bugs":{"url":"https://github.com/slackapi/node-slack-sdk/issues"},"dependencies":{"@slack/logger":">=1.0.0 <3.0.0","@slack/types":"^1.2.1","@types/is-stream":"^1.1.0","@types/node":">=8.9.0","@types/p-queue":"^2.3.2","axios":"^0.19.0","eventemitter3":"^3.1.0","form-data":"^2.5.0","is-stream":"^1.1.0","p-queue":"^2.4.2","p-retry":"^4.0.0"},"description":"Official library for using the Slack Platform's Web API","devDependencies":{"@aoberoi/capture-console":"^1.1.0","@types/chai":"^4.1.7","@types/mocha":"^5.2.6","busboy":"^0.3.0","chai":"^4.2.0","codecov":"^3.2.0","mocha":"^6.0.2","nock":"^10.0.6","nyc":"^14.1.1","shelljs":"^0.8.3","shx":"^0.3.2","sinon":"^7.2.7","source-map-support":"^0.5.10","ts-node":"^8.0.3","tslint":"^5.13.1","tslint-config-airbnb":"^5.11.1","typescript":"^3.3.3333"},"engines":{"node":">= 8.9.0","npm":">= 5.5.1"},"files":["dist/**/*"],"homepage":"https://slack.dev/node-slack-sdk/web-api","keywords":["slack","web-api","bot","client","http","api","proxy","rate-limiting","pagination"],"license":"MIT","main":"dist/index.js","name":"@slack/web-api","publishConfig":{"access":"public"},"repository":{"type":"git","url":"git+https://github.com/slackapi/node-slack-sdk.git"},"scripts":{"build":"npm run build:clean && tsc","build:clean":"shx rm -rf ./dist ./coverage ./.nyc_output","coverage":"codecov -F webapi --root=$PWD","lint":"tslint --project .","prepare":"npm run build","test":"npm run build && nyc mocha --config .mocharc.json src/*.spec.js"},"types":"./dist/index.d.ts","version":"5.9.0"};
 
 /***/ }),
 /* 60 */,
@@ -7663,7 +7667,7 @@ function run() {
                 });
             }
             const endTime = new Date();
-            s3.uploadBuildTime(startTime, endTime, imageName, 'success', 'NoError');
+            s3.uploadBuildTime(startTime, endTime, registry, imageName, 'success', 'NoError');
             const elapsedSec = (endTime.getTime() - startTime.getTime()) / 1000;
             const buildTime = `${Math.floor(elapsedSec / 60)}min ${elapsedSec % 60}sec`;
             notification.notifyReadyToDeploy(thisAction, imageName, buildTime, (_a = docker.builtImage) === null || _a === void 0 ? void 0 : _a.tags.join(', '));
@@ -7696,7 +7700,9 @@ function run() {
             js_1.default.notify(e);
             const endTime = new Date();
             const imageName = core.getInput('image_name');
-            s3.uploadBuildTime(startTime, endTime, imageName, 'fail', errorReason);
+            if (registry) {
+                s3.uploadBuildTime(startTime, endTime, registry, imageName, 'fail', errorReason);
+            }
             core.setFailed(e);
         }
     });
@@ -10357,7 +10363,7 @@ module.exports = require("assert");
 /* 361 */
 /***/ (function(module) {
 
-module.exports = {"_from":"axios","_id":"axios@0.19.2","_inBundle":false,"_integrity":"sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==","_location":"/axios","_phantomChildren":{},"_requested":{"type":"tag","registry":true,"raw":"axios","name":"axios","escapedName":"axios","rawSpec":"","saveSpec":null,"fetchSpec":"latest"},"_requiredBy":["#USER","/","/@slack/bolt","/@slack/web-api"],"_resolved":"https://registry.npmjs.org/axios/-/axios-0.19.2.tgz","_shasum":"3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27","_spec":"axios","_where":"/Users/kaku-junichi/Workspace/image_assembly_line","author":{"name":"Matt Zabriskie"},"browser":{"./lib/adapters/http.js":"./lib/adapters/xhr.js"},"bugs":{"url":"https://github.com/axios/axios/issues"},"bundleDependencies":false,"bundlesize":[{"path":"./dist/axios.min.js","threshold":"5kB"}],"dependencies":{"follow-redirects":"1.5.10"},"deprecated":false,"description":"Promise based HTTP client for the browser and node.js","devDependencies":{"bundlesize":"^0.17.0","coveralls":"^3.0.0","es6-promise":"^4.2.4","grunt":"^1.0.2","grunt-banner":"^0.6.0","grunt-cli":"^1.2.0","grunt-contrib-clean":"^1.1.0","grunt-contrib-watch":"^1.0.0","grunt-eslint":"^20.1.0","grunt-karma":"^2.0.0","grunt-mocha-test":"^0.13.3","grunt-ts":"^6.0.0-beta.19","grunt-webpack":"^1.0.18","istanbul-instrumenter-loader":"^1.0.0","jasmine-core":"^2.4.1","karma":"^1.3.0","karma-chrome-launcher":"^2.2.0","karma-coverage":"^1.1.1","karma-firefox-launcher":"^1.1.0","karma-jasmine":"^1.1.1","karma-jasmine-ajax":"^0.1.13","karma-opera-launcher":"^1.0.0","karma-safari-launcher":"^1.0.0","karma-sauce-launcher":"^1.2.0","karma-sinon":"^1.0.5","karma-sourcemap-loader":"^0.3.7","karma-webpack":"^1.7.0","load-grunt-tasks":"^3.5.2","minimist":"^1.2.0","mocha":"^5.2.0","sinon":"^4.5.0","typescript":"^2.8.1","url-search-params":"^0.10.0","webpack":"^1.13.1","webpack-dev-server":"^1.14.1"},"homepage":"https://github.com/axios/axios","keywords":["xhr","http","ajax","promise","node"],"license":"MIT","main":"index.js","name":"axios","repository":{"type":"git","url":"git+https://github.com/axios/axios.git"},"scripts":{"build":"NODE_ENV=production grunt build","coveralls":"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js","examples":"node ./examples/server.js","fix":"eslint --fix lib/**/*.js","postversion":"git push && git push --tags","preversion":"npm test","start":"node ./sandbox/server.js","test":"grunt test && bundlesize","version":"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json"},"typings":"./index.d.ts","version":"0.19.2"};
+module.exports = {"_args":[["axios@0.19.2","/app"]],"_from":"axios@0.19.2","_id":"axios@0.19.2","_inBundle":false,"_integrity":"sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==","_location":"/axios","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"axios@0.19.2","name":"axios","escapedName":"axios","rawSpec":"0.19.2","saveSpec":null,"fetchSpec":"0.19.2"},"_requiredBy":["/","/@slack/bolt","/@slack/web-api"],"_resolved":"https://registry.npmjs.org/axios/-/axios-0.19.2.tgz","_spec":"0.19.2","_where":"/app","author":{"name":"Matt Zabriskie"},"browser":{"./lib/adapters/http.js":"./lib/adapters/xhr.js"},"bugs":{"url":"https://github.com/axios/axios/issues"},"bundlesize":[{"path":"./dist/axios.min.js","threshold":"5kB"}],"dependencies":{"follow-redirects":"1.5.10"},"description":"Promise based HTTP client for the browser and node.js","devDependencies":{"bundlesize":"^0.17.0","coveralls":"^3.0.0","es6-promise":"^4.2.4","grunt":"^1.0.2","grunt-banner":"^0.6.0","grunt-cli":"^1.2.0","grunt-contrib-clean":"^1.1.0","grunt-contrib-watch":"^1.0.0","grunt-eslint":"^20.1.0","grunt-karma":"^2.0.0","grunt-mocha-test":"^0.13.3","grunt-ts":"^6.0.0-beta.19","grunt-webpack":"^1.0.18","istanbul-instrumenter-loader":"^1.0.0","jasmine-core":"^2.4.1","karma":"^1.3.0","karma-chrome-launcher":"^2.2.0","karma-coverage":"^1.1.1","karma-firefox-launcher":"^1.1.0","karma-jasmine":"^1.1.1","karma-jasmine-ajax":"^0.1.13","karma-opera-launcher":"^1.0.0","karma-safari-launcher":"^1.0.0","karma-sauce-launcher":"^1.2.0","karma-sinon":"^1.0.5","karma-sourcemap-loader":"^0.3.7","karma-webpack":"^1.7.0","load-grunt-tasks":"^3.5.2","minimist":"^1.2.0","mocha":"^5.2.0","sinon":"^4.5.0","typescript":"^2.8.1","url-search-params":"^0.10.0","webpack":"^1.13.1","webpack-dev-server":"^1.14.1"},"homepage":"https://github.com/axios/axios","keywords":["xhr","http","ajax","promise","node"],"license":"MIT","main":"index.js","name":"axios","repository":{"type":"git","url":"git+https://github.com/axios/axios.git"},"scripts":{"build":"NODE_ENV=production grunt build","coveralls":"cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js","examples":"node ./examples/server.js","fix":"eslint --fix lib/**/*.js","postversion":"git push && git push --tags","preversion":"npm test","start":"node ./sandbox/server.js","test":"grunt test && bundlesize","version":"npm run build && grunt version && git add -A dist && git add CHANGELOG.md bower.json package.json"},"typings":"./index.d.ts","version":"0.19.2"};
 
 /***/ }),
 /* 362 */,
@@ -23463,13 +23469,14 @@ function uploadVulnerability(rowJson) {
     });
 }
 exports.uploadVulnerability = uploadVulnerability;
-function uploadBuildTime(startTime, endTime, repositoryName, buildResult, buildReason) {
+function uploadBuildTime(startTime, endTime, registry, repositoryName, buildResult, buildReason) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!process.env.METRICS_BUCKET_NAME) {
             throw new Error('No bucket name.');
         }
         const bucketName = process.env.METRICS_BUCKET_NAME;
-        const latestImage = yield ecr.getLatestImage(repositoryName);
+        const registryId = registry.split('.')[0];
+        const latestImage = yield ecr.getLatestImage(repositoryName, registryId);
         if (!latestImage[0].imagePushedAt) {
             throw new Error('No push date.');
         }

--- a/src/ecr.ts
+++ b/src/ecr.ts
@@ -6,11 +6,18 @@ const client = new ecr({
 })
 
 export async function getLatestImage(
-  repositoryName: string
+  repositoryName: string,
+  registryId: string
 ): Promise<ecr.ImageDetailList> {
+  core.debug(`[INFORMATION]
+    repositoryName: ${repositoryName}
+    registryId: ${registryId}`)
+
   const params: ecr.Types.DescribeImagesRequest = {
     // eslint-disable-next-line object-shorthand
     repositoryName: repositoryName,
+    // eslint-disable-next-line object-shorthand
+    registryId: registryId,
     imageIds: [
       {
         imageTag: 'latest'

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,7 +112,14 @@ async function run(): Promise<void> {
     }
 
     const endTime = new Date() // UTC
-    s3.uploadBuildTime(startTime, endTime, imageName, 'success', 'NoError')
+    s3.uploadBuildTime(
+      startTime,
+      endTime,
+      registry,
+      imageName,
+      'success',
+      'NoError'
+    )
 
     const elapsedSec = (endTime.getTime() - startTime.getTime()) / 1000
     const buildTime = `${Math.floor(elapsedSec / 60)}min ${elapsedSec % 60}sec`
@@ -147,7 +154,16 @@ async function run(): Promise<void> {
     Bugsnag.notify(e)
     const endTime = new Date() // UTC
     const imageName = core.getInput('image_name')
-    s3.uploadBuildTime(startTime, endTime, imageName, 'fail', errorReason)
+    if (registry) {
+      s3.uploadBuildTime(
+        startTime,
+        endTime,
+        registry,
+        imageName,
+        'fail',
+        errorReason
+      )
+    }
 
     core.setFailed(e)
   }

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -30,6 +30,7 @@ export async function uploadVulnerability(rowJson: string): Promise<void> {
 export async function uploadBuildTime(
   startTime: Date,
   endTime: Date,
+  registry: string,
   repositoryName: string,
   buildResult: string,
   buildReason: string
@@ -38,8 +39,9 @@ export async function uploadBuildTime(
     throw new Error('No bucket name.')
   }
   const bucketName: string = process.env.METRICS_BUCKET_NAME
+  const registryId: string = registry.split('.')[0]
 
-  const latestImage = await ecr.getLatestImage(repositoryName)
+  const latestImage = await ecr.getLatestImage(repositoryName, registryId)
   if (!latestImage[0].imagePushedAt) {
     throw new Error('No push date.')
   }


### PR DESCRIPTION
ビルド時間のログが S3 にアップロードされない件の対応です。
https://freee.slack.com/archives/CUSLUDWS2/p1601003062011600

最後の push 時刻を取るために DescribeImages API を叩いていますが、デフォルトだと Assume Role したアカウントの ECR を参照します。
そのため別アカウントにある ECR を参照しようとすると、リポジトリが見つからずに例外が発生します。

> RepositoryNotFoundException: The repository with name 'xxxxxx' does not exist in the registry with id '012345678901'

`registryId` パラメータでアカウント ID を渡すと、意図したアカウントの ECR を参照することができるようになります。
ref. https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_DescribeImages.html