### PR TITLE
♻ remove checking that image exists or not

### DIFF
--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -29,7 +29,6 @@ describe('Docker#build()', () => {
   )
 
   test('build', async () => {
-    jest.spyOn(dockerUtil, 'noBuiltImage').mockResolvedValue(true)
     jest.spyOn(dockerUtil, 'latestBuiltImage').mockResolvedValueOnce({
       imageID: '1234567890',
       imageName: 'build-image/debug',
@@ -42,11 +41,6 @@ describe('Docker#build()', () => {
       tags: ['latest', commitHash]
     })
   })
-
-  test('throw error when built image exists on the machine', async () => {
-    jest.spyOn(dockerUtil, 'noBuiltImage').mockResolvedValue(false)
-    await expect(docker.build('build', true)).rejects.toThrowError()
-  })
 })
 
 describe('Docker#tag()', () => {
@@ -57,7 +51,6 @@ describe('Docker#tag()', () => {
   )
 
   test('tag', async () => {
-    jest.spyOn(dockerUtil, 'noBuiltImage').mockResolvedValue(true)
     jest.spyOn(dockerUtil, 'latestBuiltImage').mockResolvedValueOnce({
       imageID: '1234567890',
       imageName: 'build-image/debug',
@@ -79,7 +72,6 @@ describe('Docker#scan()', () => {
   )
 
   beforeAll(async () => {
-    jest.spyOn(dockerUtil, 'noBuiltImage').mockResolvedValue(true)
     jest.spyOn(dockerUtil, 'latestBuiltImage').mockResolvedValueOnce({
       imageID: '1234567890',
       imageName: 'build-image/debug',

--- a/dist/index.js
+++ b/dist/index.js
@@ -8273,9 +8273,6 @@ class Docker {
                 yield this.loginRegistery();
             }
             try {
-                if (!(yield docker_util_1.noBuiltImage())) {
-                    throw new Error('Built image exists');
-                }
                 core.info(`[Build] Registry name: ${this.registry}`);
                 core.info(`[Build] Image name: ${this.imageName}`);
                 const execParams = [target, `IMAGE_NAME=${this.imageName}`];
@@ -24334,7 +24331,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const exec = __importStar(__webpack_require__(986));
 const core = __importStar(__webpack_require__(470));
 const axios_1 = __importDefault(__webpack_require__(53));
 const qs_1 = __importDefault(__webpack_require__(386));
@@ -24367,22 +24363,6 @@ function latestBuiltImage(imageName) {
     });
 }
 exports.latestBuiltImage = latestBuiltImage;
-function noBuiltImage() {
-    return __awaiter(this, void 0, void 0, function* () {
-        let stdout = '';
-        yield exec.exec('docker', ['image', 'ls', '-q'], {
-            listeners: {
-                stdout: (data) => {
-                    stdout += data.toString();
-                }
-            }
-        });
-        const imageCount = stdout.split('\n').filter(word => !!word).length;
-        core.debug(`built image count: ${imageCount}`);
-        return imageCount <= 0;
-    });
-}
-exports.noBuiltImage = noBuiltImage;
 function dockerImageTag(imageId, repository, newTag) {
     return __awaiter(this, void 0, void 0, function* () {
         const res = yield exports.axiosInstance.post(`images/${imageId}/tag`, qs_1.default.stringify({ tag: newTag, repo: repository }));

--- a/src/docker-util.ts
+++ b/src/docker-util.ts
@@ -1,5 +1,4 @@
 import {DockerImage} from './docker'
-import * as exec from '@actions/exec'
 import * as core from '@actions/core'
 import axios from 'axios'
 import qs from 'qs'
@@ -37,24 +36,6 @@ export async function latestBuiltImage(
     imageID: builtImageID,
     tags
   }
-}
-
-// Return true when check is OK
-export async function noBuiltImage(): Promise<boolean> {
-  let stdout = ''
-
-  await exec.exec('docker', ['image', 'ls', '-q'], {
-    listeners: {
-      stdout: (data: Buffer) => {
-        stdout += data.toString()
-      }
-    }
-  })
-
-  const imageCount = stdout.split('\n').filter(word => !!word).length
-
-  core.debug(`built image count: ${imageCount}`)
-  return imageCount <= 0
 }
 
 /**

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,12 +1,7 @@
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as im from '@actions/exec/lib/interfaces'
-import {
-  latestBuiltImage,
-  noBuiltImage,
-  dockerImageTag,
-  pushDockerImage
-} from './docker-util'
+import {latestBuiltImage, dockerImageTag, pushDockerImage} from './docker-util'
 import {BuildError, ScanError, PushError, TaggingError} from './error'
 import {Vulnerability} from './types'
 import {notifyVulnerability} from './notification'
@@ -42,9 +37,6 @@ export default class Docker {
       await this.loginRegistery()
     }
     try {
-      if (!(await noBuiltImage())) {
-        throw new Error('Built image exists')
-      }
       core.info(`[Build] Registry name: ${this.registry}`)
       core.info(`[Build] Image name: ${this.imageName}`)
       const execParams = [target, `IMAGE_NAME=${this.imageName}`]


### PR DESCRIPTION
あまり本質的なチェックではない上、workflow によってはじゃまになるので docker build を行う時の `noBuiltImage()` のチェックを外しました