### PR TITLE
Docker image に強制的に latest タグを付ける

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7710,6 +7710,9 @@ function run() {
                 }
                 else {
                     const upstreamRepo = docker.upstreamRepository();
+                    if (!docker.builtImage.tags.includes('latest')) {
+                        docker.builtImage.tags.push('latest');
+                    }
                     yield Promise.all(docker.builtImage.tags.map((tag) => __awaiter(this, void 0, void 0, function* () {
                         js_1.default.addMetadata('buildDetails', {
                             tag,

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,6 +94,9 @@ async function run(): Promise<void> {
         core.info('no_push: true')
       } else {
         const upstreamRepo = docker.upstreamRepository()
+        if (!docker.builtImage.tags.includes('latest')) {
+          docker.builtImage.tags.push('latest')
+        }
         await Promise.all(
           docker.builtImage.tags.map(async tag => {
             Bugsnag.addMetadata('buildDetails', {


### PR DESCRIPTION
Makefile の中で `latest` タグが付与されていない場合、最後の push 時間を取得するために DescribeImages API を叩くと例外が発生します。

> ImageNotFoundException: The image with imageId {imageDigest:'null', imageTag:'latest'} does not exist within the repository with name 'benefit' in the registry with id '123456789012'

`latest` タグがない場合は image_assembly_line の中で強制的に付けるようにします。

## 📝 レビューポイント

build-image で検証したビルド結果を確認してください 👇

* Makefile で latest タグが指定されている場合
  * https://github.com/C-FO/build-image/runs/1218410570?check_suite_focus=true

```
[Tag] Image ID: sha256:c74084c4a53864f111515448930b087915010fad6894f1c1d815b157714a1443
[Tag] Tag to add: latest
[Tag] Image ID: sha256:c74084c4a53864f111515448930b087915010fad6894f1c1d815b157714a1443
[Tag] Tag to add: v.1.1
[Tag] Image ID: sha256:c74084c4a53864f111515448930b087915010fad6894f1c1d815b157714a1443
[Tag] Tag to add: 668fac6c70929350585a07501b7a069e86d6e9d7
```

* Makefile で latest タグが指定されていない場合
  * https://github.com/C-FO/build-image/runs/1218389162?check_suite_focus=true

```
[Tag] Image ID: sha256:7ff4874cdbd1ed1e538f646e35426af5974d64297e55d06c620d7ec0a87998bf
[Tag] Tag to add: test
[Tag] Image ID: sha256:7ff4874cdbd1ed1e538f646e35426af5974d64297e55d06c620d7ec0a87998bf
[Tag] Tag to add: v.1.1
[Tag] Image ID: sha256:7ff4874cdbd1ed1e538f646e35426af5974d64297e55d06c620d7ec0a87998bf
[Tag] Tag to add: 3ccfe3c2450b0a8da0e1a945e759d833d129d4fb
[Tag] Image ID: sha256:7ff4874cdbd1ed1e538f646e35426af5974d64297e55d06c620d7ec0a87998bf
[Tag] Tag to add: latest ← これが追加されている
```