### PR TITLE
buildが落ちている件の修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,35 +4,35 @@ on: # rebuild any PRs and main branch changes
     branches:
       - master
       - develop
-      - "releases/*"
+      - 'releases/*'
       - test
 
 jobs:
   build: # make sure build/ci work properly
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v1
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          registries: "057575985710"
-      - name: create .env file
-        run: |
-          env > .env
-      - name: run the make command
-        run: |
-          make dev.build_image
-          make dev.all
+    - uses: actions/checkout@v1
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+      with:
+        registries: '057575985710'
+    - name: create .env file
+      run: |
+        env > .env
+    - name: run the make command
+      run: |
+        make dev.build_image
+        make dev.all
   test: # make sure the action works on a clean machine without building
     runs-on: self-hosted
     env:
-      REGISTRY_NAME: "1234567890.dkr.ecr.ap-northeast-1.amazonaws.com"
-      CONTAINERKOJO_ENV: "test"
+      REGISTRY_NAME: '1234567890.dkr.ecr.ap-northeast-1.amazonaws.com'
+      CONTAINERKOJO_ENV: 'test'
     steps:
-      - uses: actions/checkout@v1
-      - uses: ./
-        with:
-          image_name: image_assembly_line/test
-          target: test.build_image
-          no_push: true
+    - uses: actions/checkout@v1
+    - uses: ./
+      with:
+        image_name: image_assembly_line/test
+        target: test.build_image
+        no_push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,30 +4,35 @@ on: # rebuild any PRs and main branch changes
     branches:
       - master
       - develop
-      - 'releases/*'
+      - "releases/*"
       - test
 
 jobs:
   build: # make sure build/ci work properly
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v1
-    - name: create .env file
-      run: |
-        env > .env
-    - name: run the make command
-      run: |
-        make dev.build_image
-        make dev.all
+      - uses: actions/checkout@v1
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registries: "057575985710"
+      - name: create .env file
+        run: |
+          env > .env
+      - name: run the make command
+        run: |
+          make dev.build_image
+          make dev.all
   test: # make sure the action works on a clean machine without building
     runs-on: self-hosted
     env:
-      REGISTRY_NAME: '1234567890.dkr.ecr.ap-northeast-1.amazonaws.com'
-      CONTAINERKOJO_ENV: 'test'
+      REGISTRY_NAME: "1234567890.dkr.ecr.ap-northeast-1.amazonaws.com"
+      CONTAINERKOJO_ENV: "test"
     steps:
-    - uses: actions/checkout@v1
-    - uses: ./
-      with:
-        image_name: image_assembly_line/test
-        target: test.build_image
-        no_push: true
+      - uses: actions/checkout@v1
+      - uses: ./
+        with:
+          image_name: image_assembly_line/test
+          target: test.build_image
+          no_push: true


### PR DESCRIPTION
https://jira-freee.atlassian.net/browse/CONTAINER-588
image_assembly_lineのactionsのbuildが落ちているのを修正する件の対応です。

401 unauthorized が出ているため、image_assembly_line側でもECR Loginするようにします。