### PR TITLE
Catch JSON parse error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8830,7 +8830,15 @@ class Docker {
                     skipDirs,
                     imageName
                 ], options);
-                const vulnerabilities = JSON.parse(trivyScanReport);
+                let trivyJsonScanReport;
+                try {
+                    trivyJsonScanReport = JSON.parse(trivyScanReport);
+                }
+                catch (e) {
+                    core.info(`[Scan Report]: ${trivyScanReport}`);
+                    throw new Error('Invalid JSON');
+                }
+                const vulnerabilities = trivyJsonScanReport;
                 if (vulnerabilities.length > 0) {
                     notification_1.notifyVulnerability(imageName, vulnerabilities, trivyScanReport);
                 }

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -96,7 +96,15 @@ export default class Docker {
         options
       )
 
-      const vulnerabilities: Vulnerability[] = JSON.parse(trivyScanReport)
+      let trivyJsonScanReport: Vulnerability[]
+      try {
+        trivyJsonScanReport = JSON.parse(trivyScanReport)
+      } catch (e) {
+        core.info(`[Scan Report]: ${trivyScanReport}`)
+        throw new Error('Invalid JSON')
+      }
+
+      const vulnerabilities: Vulnerability[] = trivyJsonScanReport
       if (vulnerabilities.length > 0) {
         notifyVulnerability(imageName, vulnerabilities, trivyScanReport)
       }


### PR DESCRIPTION
trivy コマンドの標準出力が大きい場合、`Buffer` のサイズを超えてしまい途中で切られてしまいます。
その結果、Invalida な JSON をパースしようとして CI が落ちてしまいますが、エラーメッセージが分かりづらいため修正します。

https://github.com/C-FO/image_assembly_line/blob/647b8f2e3a0fa02dd5db37770374b14e4c544f46/src/docker.ts#L71-L73

`@actions/exec/lib/interfaces` のコードを確認してみましたが、標準出力は `Buffer` でしか受け取れませんでした。
https://github.com/actions/toolkit/blob/main/packages/exec/src/interfaces.ts