### PR TITLE
trivyの結果通知チャンネル分岐とtrivyオプションを変更

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -91,6 +91,7 @@ export default class Docker {
           severityLevel,
           '--skip-dirs',
           skipDirs,
+          '--ignore-unfixed',
           imageName
         ],
         options

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -180,61 +180,9 @@ function selectChannel(imageName: string): string {
   const productmap = new Map()
 
   // 引っ掛けるためのproduct name
-  const products = [
-    'launch',
-    'wolf',
-    'ocean',
-    'nest-auth',
-    'card',
-    'goat',
-    'mynumber',
-    'benefit',
-    'cfoalpha-app',
-    'ohmu',
-    'jigsaw',
-    'deal-platform',
-    'javelin',
-    'ai-lab',
-    'convoy',
-    'freee-payroll',
-    'freee-pm',
-    'freee-ctax',
-    'freee-accounts',
-    'calc',
-    'freee-rrweb',
-    'ebis',
-    'freee-auth',
-    'freee-app-store',
-    'freee-tax-operation'
-  ]
+  const products = process.env.TRIVY_PRODUCT_NAME_LIST.split(',')
   // image name と対にするchannelID
-  const channelIds = [
-    'C014FCEJ1DL',
-    'C01SURYA4A3',
-    'C01T6FHVC7P',
-    'C01TN7TND4Z',
-    'C01T9LHR7PD',
-    'C01T2R4A3UN',
-    'C01U61WJX9T',
-    'C01T9K6LTU3',
-    'C0217FZ1B1N',
-    'C015Z5YR3FX',
-    'C01TFPTSD7W',
-    'C01T9J5QR6W',
-    'C01TN7G69GR',
-    'C01T2NJRA4W',
-    'C01P89JU0BZ',
-    'C014AUKCZ50',
-    'C014AUKCZ50',
-    'CAX1NQNAK',
-    'CU8BQ3WAK',
-    'C01T9QJT6Q3',
-    'C0240AGKPQE',
-    'C0137P1TJ5A',
-    'CU8BPSFAB',
-    'CDHQA8Z4J',
-    'CA3UUQRHN'
-  ]
+  const channelIds = process.env.TRIVY_SLACK_CHANNEL_ID_LIST.split(',')
 
   // mapへの登録
   for (let i = 0; i < products.length; i++) {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -180,9 +180,9 @@ function selectChannel(imageName: string): string {
   const productmap = new Map()
 
   // 引っ掛けるためのproduct name
-  const products = process.env.TRIVY_PRODUCT_NAME_LIST.split(',')
+  const products = String(process.env.TRIVY_PRODUCT_NAME_LIST).split(',')
   // image name と対にするchannelID
-  const channelIds = process.env.TRIVY_SLACK_CHANNEL_ID_LIST.split(',')
+  const channelIds = String(process.env.TRIVY_SLACK_CHANNEL_ID_LIST).split(',')
 
   // mapへの登録
   for (let i = 0; i < products.length; i++) {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -111,7 +111,8 @@ export async function postVulnerability(
   if (!process.env.SLACK_TRIVY_ALERT) {
     throw new Error('No channel to post.')
   }
-  const channel: string = selectChannel(imageName)
+
+  const channel = selectChannel(imageName)
   core.debug(`Channel: ${channel}`)
 
   const attachment = {
@@ -174,14 +175,12 @@ export async function postMessage(
   return client.chat.postMessage(args)
 }
 
-export async function selectChannel(
-  imageName: string
-): string {
+function selectChannel(imageName: string): string {
   // mapの宣言
-  var productmap = new Map();
+  const productmap = new Map()
 
   // 引っ掛けるためのproduct name
-  var products = [
+  const products = [
     'launch',
     'wolf',
     'ocean',
@@ -209,7 +208,7 @@ export async function selectChannel(
     'freee-tax-operation'
   ]
   // image name と対にするchannelID
-  var channelIds = [
+  const channelIds = [
     'C014FCEJ1DL',
     'C01SURYA4A3',
     'C01T6FHVC7P',
@@ -238,26 +237,18 @@ export async function selectChannel(
   ]
 
   // mapへの登録
-  for (var _i = 0; _i < products.length; _i++) {
-    var product = products[_i];
-    var channelid = channelIds[_i];
+  for (let i = 0; i < products.length; i++) {
+    const product = products[i]
+    const channelid = channelIds[i]
     productmap.set(product, channelid)
   }
 
-  // プロダクト名が定義されているか
-  var channel = null
-  for (var key of productmap.keys()) {
-    if imageName.includes(productmap.get(key)) {
-      channel = productmap.get(key)
-      break;
+  // プロダクト名が定義されていたら対応するチャンネルIDを返す
+  for (const key of productmap.keys()) {
+    if (imageName.includes(key)) {
+      return productmap.get(key)
     }
   }
 
-  // 当てはまるものがなかった場合はtrivy_alertに投げる(例外的な奴)
-  if (!channel) {
-    channel = process.env.SLACK_TRIVY_ALERT
-  }
-
-  // channlIDを返す
-  return channel
+  return String(process.env.SLACK_TRIVY_ALERT)
 }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -111,7 +111,7 @@ export async function postVulnerability(
   if (!process.env.SLACK_TRIVY_ALERT) {
     throw new Error('No channel to post.')
   }
-  const channel: string = process.env.SLACK_TRIVY_ALERT
+  const channel: string = selectChannel(imageName)
   core.debug(`Channel: ${channel}`)
 
   const attachment = {
@@ -172,4 +172,92 @@ export async function postMessage(
   }
 
   return client.chat.postMessage(args)
+}
+
+export async function selectChannel(
+  imageName: string
+): string {
+  // mapの宣言
+  var productmap = new Map();
+
+  // 引っ掛けるためのproduct name
+  var products = [
+    'launch',
+    'wolf',
+    'ocean',
+    'nest-auth',
+    'card',
+    'goat',
+    'mynumber',
+    'benefit',
+    'cfoalpha-app',
+    'ohmu',
+    'jigsaw',
+    'deal-platform',
+    'javelin',
+    'ai-lab',
+    'convoy',
+    'freee-payroll',
+    'freee-pm',
+    'freee-ctax',
+    'freee-accounts',
+    'calc',
+    'freee-rrweb',
+    'ebis',
+    'freee-auth',
+    'freee-app-store',
+    'freee-tax-operation'
+  ]
+  // image name と対にするchannelID
+  var channelIds = [
+    'C014FCEJ1DL',
+    'C01SURYA4A3',
+    'C01T6FHVC7P',
+    'C01TN7TND4Z',
+    'C01T9LHR7PD',
+    'C01T2R4A3UN',
+    'C01U61WJX9T',
+    'C01T9K6LTU3',
+    'C0217FZ1B1N',
+    'C015Z5YR3FX',
+    'C01TFPTSD7W',
+    'C01T9J5QR6W',
+    'C01TN7G69GR',
+    'C01T2NJRA4W',
+    'C01P89JU0BZ',
+    'C014AUKCZ50',
+    'C014AUKCZ50',
+    'CAX1NQNAK',
+    'CU8BQ3WAK',
+    'C01T9QJT6Q3',
+    'C0240AGKPQE',
+    'C0137P1TJ5A',
+    'CU8BPSFAB',
+    'CDHQA8Z4J',
+    'CA3UUQRHN'
+  ]
+
+  // mapへの登録
+  for (var _i = 0; _i < products.length; _i++) {
+    var product = products[_i];
+    var channelid = channelIds[_i];
+    productmap.set(product, channelid)
+  }
+
+  // プロダクト名が定義されているか
+  var channel = null
+  for (var key of productmap.keys()) {
+    if imageName.includes(productmap.get(key)) {
+      channel = productmap.get(key)
+      break;
+    }
+  }
+
+  // 当てはまるものがなかった場合はtrivy_alertに投げる(例外的な奴)
+  if (!channel) {
+    channel = process.env.SLACK_TRIVY_ALERT
+  }
+
+  // channlIDを返す
+  return channel
 }


### PR DESCRIPTION
trivyに関するあれこれ
やったこと
- trivyの結果通知先を各プロダクトのデプロイ先に投げるために分岐の追加
- trivyのスキャンオプションに `--ignore-unfixed`を追加

JIRA(チャンネルID他洗い出し):  https://jira-freee.atlassian.net/browse/PSIRT-1576
JIRA(そもそものタスク): https://jira-freee.atlassian.net/browse/PSIRT-1519 & https://jira-freee.atlassian.net/browse/PSIRT-1520
大枠: https://freee.kibe.la/@liva/40758

※大枠からの修正点
バッチ処理でスキャン→現状踏襲