### PR TITLE
🐛  change output at multi tags

### DIFF
--- a/__tests__/deliver.test.ts
+++ b/__tests__/deliver.test.ts
@@ -19,7 +19,7 @@ describe('setDeliver()', () => {
     })
     expect(setOutput).toHaveBeenCalledWith('built_image_name', image.imageName)
     expect(setOutput).toHaveBeenCalledWith('built_image_id', image.imageID)
-    expect(setOutput).toHaveBeenCalledWith('built_image_tag', image.tags[0])
+    expect(setOutput).toHaveBeenCalledWith('built_image_tags', image.tags.join(','))
     expect(setOutput).toHaveBeenCalledWith('git_hub_run_id', gitHubRunID)
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -9185,7 +9185,7 @@ function setDelivery(delivery) {
     return __awaiter(this, void 0, void 0, function* () {
         core.setOutput('built_image_name', delivery.dockerImage.imageName);
         core.setOutput('built_image_id', delivery.dockerImage.imageID);
-        core.setOutput('built_image_tag', delivery.dockerImage.tags[0]);
+        core.setOutput('built_image_tags', delivery.dockerImage.tags.join(','));
         core.setOutput('git_hub_run_id', delivery.gitHubRunID);
     });
 }

--- a/src/deliver.ts
+++ b/src/deliver.ts
@@ -9,6 +9,6 @@ export interface Delivery {
 export async function setDelivery(delivery: Delivery): Promise<void> {
   core.setOutput('built_image_name', delivery.dockerImage.imageName)
   core.setOutput('built_image_id', delivery.dockerImage.imageID)
-  core.setOutput('built_image_tag', delivery.dockerImage.tags[0])
+  core.setOutput('built_image_tags', delivery.dockerImage.tags.join(','))
   core.setOutput('git_hub_run_id', delivery.gitHubRunID)
 }


### PR DESCRIPTION
outputの `built_image_tag` は `latest` しか渡ってこないことが判明したため、
`built_image_tags` に変更して、カンマ区切りで渡すようにする
（もともと、Imageのタグはカンマ区切りで管理されているので、カンマ区切りで渡す分には問題はなさそう）