### PR TITLE
exit codeを1にして検出されたら落とす

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: 'CRITICAL' # Available values: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
   scan_exit_code:
     description: 'Exit code when vulnerabilities were found'
-    default: '0'
+    default: '1'
   build_directory:
     description: 'where to run make command'
     default: './'


### PR DESCRIPTION
trivyのオプションにある`exit-code`を`0`から`1`にして、脆弱性が検出された場合ciが落ちるようにする