### PR TITLE
trivy scanの結果をslackに流すか選べるようにする

### DIFF
--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -82,19 +82,19 @@ describe('Docker#scan()', () => {
 
   test('scan passed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
-    const result = await docker.scan('CRITICAL', '0', 'os', 'true')
+    const result = await docker.scan('CRITICAL', '0', 'os', true)
     expect(result).toEqual(0)
   })
 
   test('scan passed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
-    const result = await docker.scan('HIGH', '0', 'os', 'true')
+    const result = await docker.scan('HIGH', '0', 'os', true)
     expect(result).toEqual(0)
   })
 
   test('scan failed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(1)
-    const result = await docker.scan('CRITICAL', '1', 'os', 'true')
+    const result = await docker.scan('CRITICAL', '1', 'os', true)
     expect(result).toEqual(1)
   })
 })

--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -82,19 +82,19 @@ describe('Docker#scan()', () => {
 
   test('scan passed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
-    const result = await docker.scan('CRITICAL', '0', 'os')
+    const result = await docker.scan('CRITICAL', '0', 'os', 'true')
     expect(result).toEqual(0)
   })
 
   test('scan passed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
-    const result = await docker.scan('HIGH', '0', 'os')
+    const result = await docker.scan('HIGH', '0', 'os', 'true')
     expect(result).toEqual(0)
   })
 
   test('scan failed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(1)
-    const result = await docker.scan('CRITICAL', '1', 'os')
+    const result = await docker.scan('CRITICAL', '1', 'os', 'true')
     expect(result).toEqual(1)
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   trivy_vuln_type:
     description: 'comma-separated list of vulnerability types (os,library)'
     default: 'os'
+  notify_trivy_alert:
+    description: 'notify trivy alert to slack channel'
+    default: 'true'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -8061,6 +8061,7 @@ function run() {
             const noPush = core.getInput('no_push').toString() === 'true';
             const buildDirectory = core.getInput('build_directory');
             const trivyVulnType = core.getInput('trivy_vuln_type');
+            const notifyTrivyAlert = core.getInput('notify_trivy_alert');
             const docker = new docker_1.default(registry, imageName, commitHash);
             js_1.default.addMetadata('buildDetails', {
                 builtImage: docker.builtImage,
@@ -8074,6 +8075,7 @@ function run() {
       severity_level: ${severityLevel.toString()}
       scan_exit_code: ${scanExitCode.toString()}
       trivy_vuln_type: ${trivyVulnType.toString()}
+      notify_trivy_alert: ${notifyTrivyAlert.toString()}
       no_push: ${noPush.toString()}
       docker: ${JSON.stringify(docker)}`);
             try {
@@ -8083,7 +8085,7 @@ function run() {
             finally {
                 process.chdir(actionDirectory);
             }
-            yield docker.scan(severityLevel, scanExitCode, trivyVulnType);
+            yield docker.scan(severityLevel, scanExitCode, trivyVulnType, notifyTrivyAlert);
             if (docker.builtImage && gitHubRunID) {
                 if (noPush) {
                     core.info('no_push: true');
@@ -8797,7 +8799,7 @@ class Docker {
             }
         });
     }
-    scan(severityLevel, scanExitCode, trivyVulnType) {
+    scan(severityLevel, scanExitCode, trivyVulnType, notifyTrivyAlert) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
                 if (!this._builtImage) {
@@ -8844,7 +8846,7 @@ class Docker {
                     throw new Error('Invalid JSON');
                 }
                 const vulnerabilities = trivyJsonScanReport;
-                if (vulnerabilities.length > 0) {
+                if (notifyTrivyAlert === 'true' && vulnerabilities.length > 0) {
                     notification_1.notifyVulnerability(imageName, vulnerabilities, trivyScanReport);
                 }
                 return result;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8061,7 +8061,7 @@ function run() {
             const noPush = core.getInput('no_push').toString() === 'true';
             const buildDirectory = core.getInput('build_directory');
             const trivyVulnType = core.getInput('trivy_vuln_type');
-            const notifyTrivyAlert = core.getInput('notify_trivy_alert');
+            const notifyTrivyAlert = core.getInput('notify_trivy_alert').toString() === 'true';
             const docker = new docker_1.default(registry, imageName, commitHash);
             js_1.default.addMetadata('buildDetails', {
                 builtImage: docker.builtImage,
@@ -8846,7 +8846,7 @@ class Docker {
                     throw new Error('Invalid JSON');
                 }
                 const vulnerabilities = trivyJsonScanReport;
-                if (notifyTrivyAlert === 'true' && vulnerabilities.length > 0) {
+                if (notifyTrivyAlert && vulnerabilities.length > 0) {
                     notification_1.notifyVulnerability(imageName, vulnerabilities, trivyScanReport);
                 }
                 return result;

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -54,7 +54,12 @@ export default class Docker {
     }
   }
 
-  async scan(severityLevel: string, scanExitCode: string, trivyVulnType: string): Promise<number> {
+  async scan(
+    severityLevel: string,
+    scanExitCode: string,
+    trivyVulnType: string,
+    notifyTrivyAlert: string
+  ): Promise<number> {
     try {
       if (!this._builtImage) {
         throw new Error('No built image to scan')
@@ -108,7 +113,7 @@ export default class Docker {
       }
 
       const vulnerabilities: Vulnerability[] = trivyJsonScanReport
-      if (vulnerabilities.length > 0) {
+      if (notifyTrivyAlert === 'true' && vulnerabilities.length > 0) {
         notifyVulnerability(imageName, vulnerabilities, trivyScanReport)
       }
 

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -58,7 +58,7 @@ export default class Docker {
     severityLevel: string,
     scanExitCode: string,
     trivyVulnType: string,
-    notifyTrivyAlert: string
+    notifyTrivyAlert: boolean
   ): Promise<number> {
     try {
       if (!this._builtImage) {
@@ -113,7 +113,7 @@ export default class Docker {
       }
 
       const vulnerabilities: Vulnerability[] = trivyJsonScanReport
-      if (notifyTrivyAlert === 'true' && vulnerabilities.length > 0) {
+      if (notifyTrivyAlert && vulnerabilities.length > 0) {
         notifyVulnerability(imageName, vulnerabilities, trivyScanReport)
       }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,8 @@ async function run(): Promise<void> {
     const noPush = core.getInput('no_push').toString() === 'true'
     const buildDirectory = core.getInput('build_directory')
     const trivyVulnType = core.getInput('trivy_vuln_type')
-    const notifyTrivyAlert = core.getInput('notify_trivy_alert').toString() === 'true'
+    const notifyTrivyAlert =
+      core.getInput('notify_trivy_alert').toString() === 'true'
 
     const docker = new Docker(registry, imageName, commitHash)
     Bugsnag.addMetadata('buildDetails', {
@@ -91,7 +92,12 @@ async function run(): Promise<void> {
       process.chdir(actionDirectory)
     }
 
-    await docker.scan(severityLevel, scanExitCode, trivyVulnType, notifyTrivyAlert)
+    await docker.scan(
+      severityLevel,
+      scanExitCode,
+      trivyVulnType,
+      notifyTrivyAlert
+    )
 
     if (docker.builtImage && gitHubRunID) {
       if (noPush) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,7 @@ async function run(): Promise<void> {
     const noPush = core.getInput('no_push').toString() === 'true'
     const buildDirectory = core.getInput('build_directory')
     const trivyVulnType = core.getInput('trivy_vuln_type')
-    const notifyTrivyAlert = core.getInput('notify_trivy_alert')
+    const notifyTrivyAlert = core.getInput('notify_trivy_alert').toString() === 'true'
 
     const docker = new Docker(registry, imageName, commitHash)
     Bugsnag.addMetadata('buildDetails', {

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,7 @@ async function run(): Promise<void> {
     const noPush = core.getInput('no_push').toString() === 'true'
     const buildDirectory = core.getInput('build_directory')
     const trivyVulnType = core.getInput('trivy_vuln_type')
+    const notifyTrivyAlert = core.getInput('notify_trivy_alert')
 
     const docker = new Docker(registry, imageName, commitHash)
     Bugsnag.addMetadata('buildDetails', {
@@ -79,6 +80,7 @@ async function run(): Promise<void> {
       severity_level: ${severityLevel.toString()}
       scan_exit_code: ${scanExitCode.toString()}
       trivy_vuln_type: ${trivyVulnType.toString()}
+      notify_trivy_alert: ${notifyTrivyAlert.toString()}
       no_push: ${noPush.toString()}
       docker: ${JSON.stringify(docker)}`)
 
@@ -89,7 +91,7 @@ async function run(): Promise<void> {
       process.chdir(actionDirectory)
     }
 
-    await docker.scan(severityLevel, scanExitCode, trivyVulnType)
+    await docker.scan(severityLevel, scanExitCode, trivyVulnType, notifyTrivyAlert)
 
     if (docker.builtImage && gitHubRunID) {
       if (noPush) {


### PR DESCRIPTION
### チケット
https://jira-freee.atlassian.net/browse/PSIRT-1953

### 変更内容
trivy scanの結果をslackに流す・流さないを選べるようにする
develop branchにmergeするたび流れているとalertの数が多くなるので特定のbranchへのmergeの際以外はtrivyのscan結果をslackに流さないようにすることができる


### 動作確認
`notify_trivy_alert`をfalseにすることでslack通知が行われないようになることを確認
https://github.com/C-FO/build-image/runs/4160123279?check_suite_focus=true