### PR TITLE
trivyのアラートを飛ばすチャンネルをオプションでも指定できるように

### DIFF
--- a/__tests__/docker-util.test.ts
+++ b/__tests__/docker-util.test.ts
@@ -17,14 +17,14 @@ describe('latestBuiltImage()', () => {
     expect(builtImage.tags).toContain('1.11') // store tags for same ID
   })
 
-  test('throw error if there is no built image', async () => {
+  test('throw error if there is no built image', () => {
     const imageName = 'noimages/app'
     jest
       .spyOn(dockerUtil, 'dockerImageLs')
       .mockImplementation(() => Promise.resolve([]))
 
     const result = dockerUtil.latestBuiltImage(imageName)
-    await expect(result).rejects.toThrowError()
+    expect(result).rejects.toThrowError()
   })
 })
 

--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -82,19 +82,19 @@ describe('Docker#scan()', () => {
 
   test('scan passed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
-    const result = await docker.scan('CRITICAL', '0', 'os', true)
+    const result = await docker.scan('CRITICAL', '0', 'os', true, '')
     expect(result).toEqual(0)
   })
 
   test('scan passed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(0)
-    const result = await docker.scan('HIGH', '0', 'os', true)
+    const result = await docker.scan('HIGH', '0', 'os', true, '')
     expect(result).toEqual(0)
   })
 
   test('scan failed', async () => {
     jest.spyOn(exec, 'exec').mockResolvedValueOnce(1)
-    const result = await docker.scan('CRITICAL', '1', 'os', true)
+    const result = await docker.scan('CRITICAL', '1', 'os', true, '')
     expect(result).toEqual(1)
   })
 })

--- a/__tests__/slack.test.ts
+++ b/__tests__/slack.test.ts
@@ -83,7 +83,7 @@ describe('postVulnerability()', () => {
     }
 
     process.env.SLACK_TRIVY_ALERT = process.env.SLACK_CICD_NOTIFICATION_TEST
-    const result = await slack.postVulnerability(imageName, target, cve)
+    const result = await slack.postVulnerability(imageName, target, cve, '')
     expect(result.ok).toBe(true)
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   notify_trivy_alert:
     description: 'notify trivy alert to slack channel'
     default: 'true'
+  slack_channel_id:
+    description: 'slack channel id for trivy alert'
+    default: ''
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -58,7 +58,8 @@ export default class Docker {
     severityLevel: string,
     scanExitCode: string,
     trivyVulnType: string,
-    notifyTrivyAlert: boolean
+    notifyTrivyAlert: boolean,
+    slackChannelId: string
   ): Promise<number> {
     try {
       if (!this._builtImage) {
@@ -114,7 +115,7 @@ export default class Docker {
 
       const vulnerabilities: Vulnerability[] = trivyJsonScanReport
       if (notifyTrivyAlert && vulnerabilities.length > 0) {
-        notifyVulnerability(imageName, vulnerabilities, trivyScanReport)
+        notifyVulnerability(imageName, vulnerabilities, trivyScanReport, slackChannelId)
       }
 
       return result

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -115,7 +115,12 @@ export default class Docker {
 
       const vulnerabilities: Vulnerability[] = trivyJsonScanReport
       if (notifyTrivyAlert && vulnerabilities.length > 0) {
-        notifyVulnerability(imageName, vulnerabilities, trivyScanReport, slackChannelId)
+        notifyVulnerability(
+          imageName,
+          vulnerabilities,
+          trivyScanReport,
+          slackChannelId
+        )
       }
 
       return result

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,7 @@ async function run(): Promise<void> {
     const trivyVulnType = core.getInput('trivy_vuln_type')
     const notifyTrivyAlert =
       core.getInput('notify_trivy_alert').toString() === 'true'
+    const slackChannelId = core.getInput('slack_channel_id')
 
     const docker = new Docker(registry, imageName, commitHash)
     Bugsnag.addMetadata('buildDetails', {
@@ -82,6 +83,7 @@ async function run(): Promise<void> {
       scan_exit_code: ${scanExitCode.toString()}
       trivy_vuln_type: ${trivyVulnType.toString()}
       notify_trivy_alert: ${notifyTrivyAlert.toString()}
+      slack_channel_id: ${slackChannelId.toString()}
       no_push: ${noPush.toString()}
       docker: ${JSON.stringify(docker)}`)
 
@@ -96,7 +98,8 @@ async function run(): Promise<void> {
       severityLevel,
       scanExitCode,
       trivyVulnType,
-      notifyTrivyAlert
+      notifyTrivyAlert,
+      slackChannelId
     )
 
     if (docker.builtImage && gitHubRunID) {

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -6,14 +6,20 @@ import * as s3 from './s3'
 export function notifyVulnerability(
   imageName: string,
   vulnerabilities: Vulnerability[],
-  rowJson: string
+  rowJson: string,
+  slackChannelId: string
 ): void {
   try {
     // Notify Slack
     for (const result of vulnerabilities) {
       if (result.Vulnerabilities != null) {
         for (const vulnerability of result.Vulnerabilities) {
-          slack.postVulnerability(imageName, result.Target, vulnerability)
+          slack.postVulnerability(
+            imageName,
+            result.Target,
+            vulnerability,
+            slackChannelId
+          )
         }
       }
     }

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -106,13 +106,16 @@ export function failedAttachment(build: BuildAction): types.MessageAttachment {
 export async function postVulnerability(
   imageName: string,
   target: string,
-  cve: CVE
+  cve: CVE,
+  slackChannelId: string
 ): Promise<api.WebAPICallResult> {
   if (!process.env.SLACK_TRIVY_ALERT) {
     throw new Error('No channel to post.')
   }
 
-  const channel = selectChannel(imageName)
+  const channel =
+    slackChannelId !== '' ? slackChannelId : selectChannel(imageName)
+
   core.debug(`Channel: ${channel}`)
 
   const attachment = {


### PR DESCRIPTION
`--slack_channel_id`でtrivyのアラート飛ばす先のチャンネルを指定できるようにする
 
チャンネルIDを指定していると読み取っていることを確認しました（チャンネルにappが入っていないので通知は失敗する）