### PR TITLE
trivyのtimeoutオプションを追加

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8837,6 +8837,8 @@ class Docker {
                     severityLevel,
                     '--vuln-type',
                     trivyVulnType,
+                    '--timeout',
+                    '10m',
                     '--skip-dirs',
                     skipDirs,
                     '--ignore-unfixed',

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -99,6 +99,8 @@ export default class Docker {
           severityLevel,
           '--vuln-type',
           trivyVulnType,
+          '--timeout',
+          '10m',
           '--skip-dirs',
           skipDirs,
           '--ignore-unfixed',


### PR DESCRIPTION
workflowでtrivyがエラーを出している件の対応
`--timeout`optionを追加、10分にする