### PR TITLE
trivyのバージョン上げにあたっての修正

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8826,9 +8826,9 @@ class Docker {
                 const skipDirs = '/usr/local/rvm/gems';
                 const trivyDebugOption = trivyDebug ? '--debug' : '--quiet';
                 const result = yield exec.exec('trivy', [
+                    trivyDebugOption,
                     'image',
                     '--no-progress',
-                    trivyDebugOption,
                     '--format',
                     'json',
                     '--exit-code',

--- a/dist/index.js
+++ b/dist/index.js
@@ -8825,8 +8825,7 @@ class Docker {
                 core.info(`[Scan] Image name: ${imageName}`);
                 const skipDirs = '/usr/local/rvm/gems';
                 const trivyDebugOption = trivyDebug ? '--debug' : '--quiet';
-                const result = yield exec.exec('trivy', [
-                    '--light',
+                const result = yield exec.exec('trivy image', [
                     '--no-progress',
                     trivyDebugOption,
                     '--format',

--- a/dist/index.js
+++ b/dist/index.js
@@ -8825,7 +8825,8 @@ class Docker {
                 core.info(`[Scan] Image name: ${imageName}`);
                 const skipDirs = '/usr/local/rvm/gems';
                 const trivyDebugOption = trivyDebug ? '--debug' : '--quiet';
-                const result = yield exec.exec('trivy image', [
+                const result = yield exec.exec('trivy', [
+                    'image',
                     '--no-progress',
                     trivyDebugOption,
                     '--format',

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -86,9 +86,8 @@ export default class Docker {
       const skipDirs = '/usr/local/rvm/gems' // comma separated
       const trivyDebugOption = trivyDebug ? '--debug' : '--quiet'
       const result = await exec.exec(
-        'trivy',
+        'trivy image',
         [
-          '--light',
           '--no-progress',
           trivyDebugOption,
           '--format',

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -88,9 +88,9 @@ export default class Docker {
       const result = await exec.exec(
         'trivy',
         [
+          trivyDebugOption,
           'image',
           '--no-progress',
-          trivyDebugOption,
           '--format',
           'json',
           '--exit-code',

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -86,8 +86,9 @@ export default class Docker {
       const skipDirs = '/usr/local/rvm/gems' // comma separated
       const trivyDebugOption = trivyDebug ? '--debug' : '--quiet'
       const result = await exec.exec(
-        'trivy image',
+        'trivy',
         [
+          'image',
           '--no-progress',
           trivyDebugOption,
           '--format',


### PR DESCRIPTION
https://jira-freee.atlassian.net/browse/PSIRT-2283

2022/08以降、v0.22以下の場合脆弱性データーベースが更新されなくなるらしいのでtrivyのバージョン上げをしたい。
それにあたって実行コマンドの修正が必要なので変更を入れました。

`trivy ~` -> `trivy image ~` 

--lighitオプションは必要なくなるので削除

--debug/--quietオプションの位置を変更